### PR TITLE
docs: replace code-only Tabs with CodeGroup

### DIFF
--- a/developers/developer-guides/integrating-initia-apps/initiadex.mdx
+++ b/developers/developer-guides/integrating-initia-apps/initiadex.mdx
@@ -33,74 +33,70 @@ public entry fun create_pair_script(
 _For more information on metadata, please refer to
 [obtaining metadata](/developers/developer-guides/vm-specific-tutorials/movevm/creating-move-coin#obtaining-metadata)._
 
-<Tabs>
-    <Tab title="CLI">
-        ```bash
-        initiad tx move execute 0x1 dex create_pair_script \
-            --args '["string:name", "string:symbol", "bigdecimal:0.001", "bigdecimal:0.8", "bigdecimal:0.2", "object:0x...", "object:0x...", "u64:100", "u64:100"]' \
-            --from [key-name] \
-            --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-            --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-        ```
-    </Tab>
-    <Tab title="InitiaJS">
-        ```ts
-        import {
-            bcs,
-            RESTClient,
-            MnemonicKey,
-            MsgExecute,
-            Wallet,
-        } from '@initia/initia.js';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 dex create_pair_script \
+    --args '["string:name", "string:symbol", "bigdecimal:0.001", "bigdecimal:0.8", "bigdecimal:0.2", "object:0x...", "object:0x...", "u64:100", "u64:100"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-        async function main() {
-          const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-              gasPrices: '0.015uinit',
-              gasAdjustment: '1.5',
-          });
+```ts InitiaJS
+import {
+    bcs,
+    RESTClient,
+    MnemonicKey,
+    MsgExecute,
+    Wallet,
+} from '@initia/initia.js';
 
-          const key = new MnemonicKey({
-              mnemonic: 'beauty sniff protect ...',
-          });
-          const wallet = new Wallet(restClient, key);
+async function main() {
+  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+      gasPrices: '0.015uinit',
+      gasAdjustment: '1.5',
+  });
 
-          const msgs = [
-              new MsgExecute(
-              key.accAddress,
-              '0x1',
-              'dex',
-              'create_pair_script',
-              [],
-              [
-                  bcs.string().serialize('name'), // name
-                  bcs.string().serialize('symbol'), // symbol
-                  bcs.bigdecimal().serialize('0.003'), // swap fee
-                  bcs.bigdecimal().serialize('0.2'), // coin a weight
-                  bcs.bigdecimal().serialize('0.8'), // coin b weight
-                  bcs.object().serialize('0x...'), // coin a
-                  bcs.object().serialize('0x...'), // coin b
-                  bcs.u64().serialize(7500000000000), // coin a amount
-                  bcs.u64().serialize(3000000000000), // coin b amount
-              ].map(v => v.toBase64())
-              ),
-          ];
+  const key = new MnemonicKey({
+      mnemonic: 'beauty sniff protect ...',
+  });
+  const wallet = new Wallet(restClient, key);
 
-          // sign tx
-          const signedTx = await wallet.createAndSignTx({ msgs });
-          // send(broadcast) tx
-          restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-          // {
-          //   height: 0,
-          //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-          //   raw_log: '[]'
-          // }
-        }
+  const msgs = [
+      new MsgExecute(
+      key.accAddress,
+      '0x1',
+      'dex',
+      'create_pair_script',
+      [],
+      [
+          bcs.string().serialize('name'), // name
+          bcs.string().serialize('symbol'), // symbol
+          bcs.bigdecimal().serialize('0.003'), // swap fee
+          bcs.bigdecimal().serialize('0.2'), // coin a weight
+          bcs.bigdecimal().serialize('0.8'), // coin b weight
+          bcs.object().serialize('0x...'), // coin a
+          bcs.object().serialize('0x...'), // coin b
+          bcs.u64().serialize(7500000000000), // coin a amount
+          bcs.u64().serialize(3000000000000), // coin b amount
+      ].map(v => v.toBase64())
+      ),
+  ];
 
-        main();
-        ```
-    </Tab>
+  // sign tx
+  const signedTx = await wallet.createAndSignTx({ msgs });
+  // send(broadcast) tx
+  restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+  // {
+  //   height: 0,
+  //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+  //   raw_log: '[]'
+  // }
+}
 
-</Tabs>
+main();
+```
+</CodeGroup>
 
 ## How to Provide Liquidity
 
@@ -127,69 +123,65 @@ public entry fun provide_liquidity_script(
 - `min_liquidity`: Minimum amount of liquidity token to receive. In case that
   the actual value is smaller than `min_liquidity`, the transaction will fail.
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad tx move execute 0x1 dex provide_liquidity_script \
-        --args '["object:0x...", "u64:100", "u64:100", "option<u64>:100"]' \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import {
-        bcs,
-        RESTClient,
-        MnemonicKey,
-        MsgExecute,
-        Wallet,
-    } from '@initia/initia.js';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 dex provide_liquidity_script \
+    --args '["object:0x...", "u64:100", "u64:100", "option<u64>:100"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-    async function main() {
-      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-          gasPrices: '0.015uinit',
-          gasAdjustment: '1.5',
-      });
+```ts InitiaJS
+import {
+    bcs,
+    RESTClient,
+    MnemonicKey,
+    MsgExecute,
+    Wallet,
+} from '@initia/initia.js';
 
-      const key = new MnemonicKey({
-          mnemonic: 'beauty sniff protect ...',
-      });
-      const wallet = new Wallet(restClient, key);
+async function main() {
+  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+      gasPrices: '0.015uinit',
+      gasAdjustment: '1.5',
+  });
 
-      const msgs = [
-          new MsgExecute(
-          key.accAddress,
-          '0x1',
-          'dex',
-          'provide_liquidity_script',
-          [],
-          [
-              bcs.object().serialize('0x...'), // pair object
-              bcs.u64().serialize(7500000000000), // coin a amount
-              bcs.u64().serialize(3000000000000), // coin b amount
-              bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
-          ].map(v => v.toBase64())
-          ),
-      ];
+  const key = new MnemonicKey({
+      mnemonic: 'beauty sniff protect ...',
+  });
+  const wallet = new Wallet(restClient, key);
 
-      // sign tx
-      const signedTx = await wallet.createAndSignTx({ msgs });
-      // send(broadcast) tx
-      restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-      // {
-      //   height: 0,
-      //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-      //   raw_log: '[]'
-      // }
-    }
+  const msgs = [
+      new MsgExecute(
+      key.accAddress,
+      '0x1',
+      'dex',
+      'provide_liquidity_script',
+      [],
+      [
+          bcs.object().serialize('0x...'), // pair object
+          bcs.u64().serialize(7500000000000), // coin a amount
+          bcs.u64().serialize(3000000000000), // coin b amount
+          bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
+      ].map(v => v.toBase64())
+      ),
+  ];
 
-    main();
-    ```
-    </Tab>
+  // sign tx
+  const signedTx = await wallet.createAndSignTx({ msgs });
+  // send(broadcast) tx
+  restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+  // {
+  //   height: 0,
+  //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+  //   raw_log: '[]'
+  // }
+}
 
-</Tabs>
+main();
+```
+</CodeGroup>
 
 ### Single Asset Provide Liquidity
 
@@ -214,69 +206,65 @@ public entry fun single_asset_provide_liquidity_script(
 - `min_liquidity`: Minimum amount of liquidity token to receive. In case that
   the actual value is smaller than `min_liquidity`, the transaction will fail.
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad tx move execute 0x1 dex single_asset_provide_liquidity_script \
-        --args '["object:0x...", "object:0x..", "u64:100", "option<u64>:100"]' \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import {
-        bcs,
-        RESTClient,
-        MnemonicKey,
-        MsgExecute,
-        Wallet,
-    } from '@initia/initia.js';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 dex single_asset_provide_liquidity_script \
+    --args '["object:0x...", "object:0x..", "u64:100", "option<u64>:100"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-    async function main() {
-      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-          gasPrices: '0.015uinit',
-          gasAdjustment: '1.5',
-      });
+```ts InitiaJS
+import {
+    bcs,
+    RESTClient,
+    MnemonicKey,
+    MsgExecute,
+    Wallet,
+} from '@initia/initia.js';
 
-      const key = new MnemonicKey({
-          mnemonic: 'beauty sniff protect ...',
-      });
-      const wallet = new Wallet(restClient, key);
+async function main() {
+  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+      gasPrices: '0.015uinit',
+      gasAdjustment: '1.5',
+  });
 
-      const msgs = [
-          new MsgExecute(
-          key.accAddress,
-          '0x1',
-          'dex',
-          'single_asset_provide_liquidity_script',
-          [],
-          [
-              bcs.object().serialize('0x...'), // pair object
-              bcs.object().serialize('0x...'), // provide asset metadata
-              bcs.u64().serialize(3000000000000), // provide amount
-              bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
-          ].map(v => v.toBase64())
-          ),
-      ];
+  const key = new MnemonicKey({
+      mnemonic: 'beauty sniff protect ...',
+  });
+  const wallet = new Wallet(restClient, key);
 
-      // sign tx
-      const signedTx = await wallet.createAndSignTx({ msgs });
-      // send(broadcast) tx
-      restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-      // {
-      //   height: 0,
-      //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-      //   raw_log: '[]'
-      // }
-    }
+  const msgs = [
+      new MsgExecute(
+      key.accAddress,
+      '0x1',
+      'dex',
+      'single_asset_provide_liquidity_script',
+      [],
+      [
+          bcs.object().serialize('0x...'), // pair object
+          bcs.object().serialize('0x...'), // provide asset metadata
+          bcs.u64().serialize(3000000000000), // provide amount
+          bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
+      ].map(v => v.toBase64())
+      ),
+  ];
 
-    main();
-    ```
-    </Tab>
+  // sign tx
+  const signedTx = await wallet.createAndSignTx({ msgs });
+  // send(broadcast) tx
+  restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+  // {
+  //   height: 0,
+  //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+  //   raw_log: '[]'
+  // }
+}
 
-</Tabs>
+main();
+```
+</CodeGroup>
 
 ## How to Withdraw Liquidity
 
@@ -301,69 +289,65 @@ public entry fun withdraw_liquidity_script(
   `coin_b` to receive. In case that the actual value is smaller than
   `min_coin_a_amount` or `min_coin_b_amount`, the transaction will fail.
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad tx move execute 0x1 dex withdraw_liquidity_script \
-        --args '["object:0x...", "u64:100", "option<u64>:100", "option<u64>:100"]' \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import {
-        bcs,
-        RESTClient,
-        MnemonicKey,
-        MsgExecute,
-        Wallet,
-    } from '@initia/initia.js';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 dex withdraw_liquidity_script \
+    --args '["object:0x...", "u64:100", "option<u64>:100", "option<u64>:100"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-    async function main() {
-    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-        gasPrices: '0.015uinit',
-        gasAdjustment: '1.5',
-    });
+```ts InitiaJS
+import {
+    bcs,
+    RESTClient,
+    MnemonicKey,
+    MsgExecute,
+    Wallet,
+} from '@initia/initia.js';
 
-    const key = new MnemonicKey({
-        mnemonic: 'beauty sniff protect ...',
-    });
-    const wallet = new Wallet(restClient, key);
+async function main() {
+const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+    gasPrices: '0.015uinit',
+    gasAdjustment: '1.5',
+});
 
-    const msgs = [
-        new MsgExecute(
-          key.accAddress,
-          '0x1',
-          'dex',
-          'withdraw_liquidity_script',
-          [],
-          [
-              bcs.object().serialize('0x...'), // pair object
-              bcs.u64().serialize(100000000), // liquidity
-              bcs.option(bcs.u64()).serialize(100000000), // min coin a amount
-              bcs.option(bcs.u64()).serialize(100000000), // min coin b amount
-          ].map(v => v.toBase64())
-        ),
-    ];
+const key = new MnemonicKey({
+    mnemonic: 'beauty sniff protect ...',
+});
+const wallet = new Wallet(restClient, key);
 
-    // sign tx
-    const signedTx = await wallet.createAndSignTx({ msgs });
-    // send(broadcast) tx
-    restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-    // {
-    //   height: 0,
-    //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-    //   raw_log: '[]'
-    // }
-    }
+const msgs = [
+    new MsgExecute(
+      key.accAddress,
+      '0x1',
+      'dex',
+      'withdraw_liquidity_script',
+      [],
+      [
+          bcs.object().serialize('0x...'), // pair object
+          bcs.u64().serialize(100000000), // liquidity
+          bcs.option(bcs.u64()).serialize(100000000), // min coin a amount
+          bcs.option(bcs.u64()).serialize(100000000), // min coin b amount
+      ].map(v => v.toBase64())
+    ),
+];
 
-    main();
-    ```
-    </Tab>
+// sign tx
+const signedTx = await wallet.createAndSignTx({ msgs });
+// send(broadcast) tx
+restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+// {
+//   height: 0,
+//   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+//   raw_log: '[]'
+// }
+}
 
-</Tabs>
+main();
+```
+</CodeGroup>
 
 ## How to Swap Pair
 
@@ -385,60 +369,55 @@ public fun get_swap_simulation(
 - `offer_metadata`: Metadata of offered coin.
 - `offer_amount`: Amount of offered coin.
 
-<Tabs>
-    <Tab title="curl">
-    ```bash
-    curl -X POST "https://rest.testnet.initia.xyz/initia/move/v1/accounts/0x1/modules/dex/view_functions/get_swap_simulation" \
-        -H "accept: application/json" \
-        -H "Content-Type: application/json" \
-        -d "{ \"args\": [ \"[BCS_ENCODED_OBJECT, BCS_ENCODED_OBJECT, BCS_ENCODED_OFFER_AMOUNT]\" ]}"
+<CodeGroup>
+```bash curl
+curl -X POST "https://rest.testnet.initia.xyz/initia/move/v1/accounts/0x1/modules/dex/view_functions/get_swap_simulation" \
+    -H "accept: application/json" \
+    -H "Content-Type: application/json" \
+    -d "{ \"args\": [ \"[BCS_ENCODED_OBJECT, BCS_ENCODED_OBJECT, BCS_ENCODED_OFFER_AMOUNT]\" ]}"
 
-    #{
-    #  "data": "\"100\"",
-    #  "events": [],
-    #  "gas_used": "5699"
-    #}
-    ```
-    </Tab>
-    <Tab title="CLI">
-    ```bash
-    initiad query move view 0x1 dex get_swap_simulation \
-        --args '["object:0x...", "object:0x...", "u64:123"]' \
-        --node [rpc-url]:[rpc-port]
+#{
+#  "data": "\"100\"",
+#  "events": [],
+#  "gas_used": "5699"
+#}
+```
 
-    # data: '"123"'
-    # events: []
-    # gas_used: "5699"
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import { RESTClient, bcs } from '@initia/initia.js';
+```bash CLI
+initiad query move view 0x1 dex get_swap_simulation \
+    --args '["object:0x...", "object:0x...", "u64:123"]' \
+    --node [rpc-url]:[rpc-port]
 
-    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-            gasPrices: '0.015uinit',
-            gasAdjustment: '1.5',
-        });
+# data: '"123"'
+# events: []
+# gas_used: "5699"
+```
 
-    restClient.move
-      .view(
-          '0x1',
-          'dex',
-          'get_swap_simulation',
-          [],
-          [
-          bcs.object().serialize('0x...').toBase64(),
-          bcs.object().serialize('0x...').toBase64(),
-          bcs.u64().serialize(100).toBase64(),
-          ]
-      )
-      .then(console.log);
+```ts InitiaJS
+import { RESTClient, bcs } from '@initia/initia.js';
 
-    // { data: '"100"', events: [], gas_used: '21371' }
-    ```
-    </Tab>
+const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.5',
+    });
 
-</Tabs>
+restClient.move
+  .view(
+      '0x1',
+      'dex',
+      'get_swap_simulation',
+      [],
+      [
+      bcs.object().serialize('0x...').toBase64(),
+      bcs.object().serialize('0x...').toBase64(),
+      bcs.u64().serialize(100).toBase64(),
+      ]
+  )
+  .then(console.log);
+
+// { data: '"100"', events: [], gas_used: '21371' }
+```
+</CodeGroup>
 
 ### Swap
 
@@ -460,69 +439,65 @@ public entry fun swap_script(
 - `min_return`: Minimum return amount of coin. In case that the actual value is
   smaller than `min_return`, the transaction will fail.
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad tx move execute 0x1 dex swap_script \
-        --args '["object:0x...", "object:0x...", "u64:100", "option<u64>:100"]' \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import {
-        bcs,
-        RESTClient,
-        MnemonicKey,
-        MsgExecute,
-        Wallet,
-    } from '@initia/initia.js';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 dex swap_script \
+    --args '["object:0x...", "object:0x...", "u64:100", "option<u64>:100"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-    async function main() {
-        const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-            gasPrices: '0.015uinit',
-            gasAdjustment: '1.5',
-        });
+```ts InitiaJS
+import {
+    bcs,
+    RESTClient,
+    MnemonicKey,
+    MsgExecute,
+    Wallet,
+} from '@initia/initia.js';
 
-        const key = new MnemonicKey({
-            mnemonic: 'beauty sniff protect ...',
-        });
-        const wallet = new Wallet(restClient, key);
+async function main() {
+    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.5',
+    });
 
-        const msgs = [
-            new MsgExecute(
-              key.accAddress,
-              '0x1',
-              'dex',
-              'swap_script',
-              [],
-              [
-                  bcs.object().serialize('0x...'), // pair object
-                  bcs.object().serialize('0x...'), // offer asset metadata
-                  bcs.u64().serialize(100000000), // offer amount
-                  bcs.option(bcs.u64()).serialize(100000000), // min return amount
-              ].map(v => v.toBase64())
-            ),
-        ];
+    const key = new MnemonicKey({
+        mnemonic: 'beauty sniff protect ...',
+    });
+    const wallet = new Wallet(restClient, key);
 
-        // sign tx
-        const signedTx = await wallet.createAndSignTx({ msgs });
-        // send(broadcast) tx
-        restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-        // {
-        //   height: 0,
-        //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-        //   raw_log: '[]'
-        // }
-    }
+    const msgs = [
+        new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'dex',
+          'swap_script',
+          [],
+          [
+              bcs.object().serialize('0x...'), // pair object
+              bcs.object().serialize('0x...'), // offer asset metadata
+              bcs.u64().serialize(100000000), // offer amount
+              bcs.option(bcs.u64()).serialize(100000000), // min return amount
+          ].map(v => v.toBase64())
+        ),
+    ];
 
-    main();
-    ```
-    </Tab>
+    // sign tx
+    const signedTx = await wallet.createAndSignTx({ msgs });
+    // send(broadcast) tx
+    restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+    // {
+    //   height: 0,
+    //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+    //   raw_log: '[]'
+    // }
+}
 
-</Tabs>
+main();
+```
+</CodeGroup>
 
 ## How to Delegate LP Tokens
 
@@ -601,38 +576,34 @@ to whitelist the LP token.
 After whitelisting the LP token, you can delegate your LP tokens to a validator.
 We can use `MsgDelegate` to delegate LP tokens.
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    # initiad tx mstaking delegate [validator-addr] [amount]
-    initiad tx mstaking delegate initvaloper1.... 100move/ff5c7412979 \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    async function delegateLP(
-        lpMetadata: string,
-        amount: number
-    ) {
-        // we can get lp denom from lp metadata by adding 'move/' prefix
-        // if lp metadata is ff5c7412979...
-        // then lp denom is move/ff5c7412979...
-        const msg = new MsgDelegate(
-            user.key.accAddress,                   // delegator
-            validator.key.valAddress,              // validator
-            `${amount}move/${lpMetadata}`          // lp token
-        )
+<CodeGroup>
+```bash CLI
+# initiad tx mstaking delegate [validator-addr] [amount]
+initiad tx mstaking delegate initvaloper1.... 100move/ff5c7412979 \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-        const signedTx = await user.createAndSignTx({ msgs: [msg] })
-        await user.rest.tx.broadcast(signedTx).catch(console.log)
-    }
-    ```
-    </Tab>
+```ts InitiaJS
+async function delegateLP(
+    lpMetadata: string,
+    amount: number
+) {
+    // we can get lp denom from lp metadata by adding 'move/' prefix
+    // if lp metadata is ff5c7412979...
+    // then lp denom is move/ff5c7412979...
+    const msg = new MsgDelegate(
+        user.key.accAddress,                   // delegator
+        validator.key.valAddress,              // validator
+        `${amount}move/${lpMetadata}`          // lp token
+    )
 
-</Tabs>
+    const signedTx = await user.createAndSignTx({ msgs: [msg] })
+    await user.rest.tx.broadcast(signedTx).catch(console.log)
+}
+```
+</CodeGroup>
 
 ## Example Code
 

--- a/developers/developer-guides/integrating-initia-apps/initiadex.mdx
+++ b/developers/developer-guides/integrating-initia-apps/initiadex.mdx
@@ -34,68 +34,68 @@ _For more information on metadata, please refer to
 [obtaining metadata](/developers/developer-guides/vm-specific-tutorials/movevm/creating-move-coin#obtaining-metadata)._
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 dex create_pair_script \
-    --args '["string:name", "string:symbol", "bigdecimal:0.001", "bigdecimal:0.8", "bigdecimal:0.2", "object:0x...", "object:0x...", "u64:100", "u64:100"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 dex create_pair_script \
+        --args '["string:name", "string:symbol", "bigdecimal:0.001", "bigdecimal:0.8", "bigdecimal:0.2", "object:0x...", "object:0x...", "u64:100", "u64:100"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-    bcs,
-    RESTClient,
-    MnemonicKey,
-    MsgExecute,
-    Wallet,
-} from '@initia/initia.js';
-
-async function main() {
-  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-      gasPrices: '0.015uinit',
-      gasAdjustment: '1.5',
-  });
-
-  const key = new MnemonicKey({
-      mnemonic: 'beauty sniff protect ...',
-  });
-  const wallet = new Wallet(restClient, key);
-
-  const msgs = [
-      new MsgExecute(
-      key.accAddress,
-      '0x1',
-      'dex',
-      'create_pair_script',
-      [],
-      [
-          bcs.string().serialize('name'), // name
-          bcs.string().serialize('symbol'), // symbol
-          bcs.bigdecimal().serialize('0.003'), // swap fee
-          bcs.bigdecimal().serialize('0.2'), // coin a weight
-          bcs.bigdecimal().serialize('0.8'), // coin b weight
-          bcs.object().serialize('0x...'), // coin a
-          bcs.object().serialize('0x...'), // coin b
-          bcs.u64().serialize(7500000000000), // coin a amount
-          bcs.u64().serialize(3000000000000), // coin b amount
-      ].map(v => v.toBase64())
-      ),
-  ];
-
-  // sign tx
-  const signedTx = await wallet.createAndSignTx({ msgs });
-  // send(broadcast) tx
-  restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-  // {
-  //   height: 0,
-  //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-  //   raw_log: '[]'
-  // }
-}
-
-main();
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+        bcs,
+        RESTClient,
+        MnemonicKey,
+        MsgExecute,
+        Wallet,
+    } from '@initia/initia.js';
+    
+    async function main() {
+      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+          gasPrices: '0.015uinit',
+          gasAdjustment: '1.5',
+      });
+    
+      const key = new MnemonicKey({
+          mnemonic: 'beauty sniff protect ...',
+      });
+      const wallet = new Wallet(restClient, key);
+    
+      const msgs = [
+          new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'dex',
+          'create_pair_script',
+          [],
+          [
+              bcs.string().serialize('name'), // name
+              bcs.string().serialize('symbol'), // symbol
+              bcs.bigdecimal().serialize('0.003'), // swap fee
+              bcs.bigdecimal().serialize('0.2'), // coin a weight
+              bcs.bigdecimal().serialize('0.8'), // coin b weight
+              bcs.object().serialize('0x...'), // coin a
+              bcs.object().serialize('0x...'), // coin b
+              bcs.u64().serialize(7500000000000), // coin a amount
+              bcs.u64().serialize(3000000000000), // coin b amount
+          ].map(v => v.toBase64())
+          ),
+      ];
+    
+      // sign tx
+      const signedTx = await wallet.createAndSignTx({ msgs });
+      // send(broadcast) tx
+      restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+      // {
+      //   height: 0,
+      //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+      //   raw_log: '[]'
+      // }
+    }
+    
+    main();
+  </CodeBlock>
 </CodeGroup>
 
 ## How to Provide Liquidity
@@ -124,63 +124,63 @@ public entry fun provide_liquidity_script(
   the actual value is smaller than `min_liquidity`, the transaction will fail.
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 dex provide_liquidity_script \
-    --args '["object:0x...", "u64:100", "u64:100", "option<u64>:100"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 dex provide_liquidity_script \
+        --args '["object:0x...", "u64:100", "u64:100", "option<u64>:100"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-    bcs,
-    RESTClient,
-    MnemonicKey,
-    MsgExecute,
-    Wallet,
-} from '@initia/initia.js';
-
-async function main() {
-  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-      gasPrices: '0.015uinit',
-      gasAdjustment: '1.5',
-  });
-
-  const key = new MnemonicKey({
-      mnemonic: 'beauty sniff protect ...',
-  });
-  const wallet = new Wallet(restClient, key);
-
-  const msgs = [
-      new MsgExecute(
-      key.accAddress,
-      '0x1',
-      'dex',
-      'provide_liquidity_script',
-      [],
-      [
-          bcs.object().serialize('0x...'), // pair object
-          bcs.u64().serialize(7500000000000), // coin a amount
-          bcs.u64().serialize(3000000000000), // coin b amount
-          bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
-      ].map(v => v.toBase64())
-      ),
-  ];
-
-  // sign tx
-  const signedTx = await wallet.createAndSignTx({ msgs });
-  // send(broadcast) tx
-  restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-  // {
-  //   height: 0,
-  //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-  //   raw_log: '[]'
-  // }
-}
-
-main();
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+        bcs,
+        RESTClient,
+        MnemonicKey,
+        MsgExecute,
+        Wallet,
+    } from '@initia/initia.js';
+    
+    async function main() {
+      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+          gasPrices: '0.015uinit',
+          gasAdjustment: '1.5',
+      });
+    
+      const key = new MnemonicKey({
+          mnemonic: 'beauty sniff protect ...',
+      });
+      const wallet = new Wallet(restClient, key);
+    
+      const msgs = [
+          new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'dex',
+          'provide_liquidity_script',
+          [],
+          [
+              bcs.object().serialize('0x...'), // pair object
+              bcs.u64().serialize(7500000000000), // coin a amount
+              bcs.u64().serialize(3000000000000), // coin b amount
+              bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
+          ].map(v => v.toBase64())
+          ),
+      ];
+    
+      // sign tx
+      const signedTx = await wallet.createAndSignTx({ msgs });
+      // send(broadcast) tx
+      restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+      // {
+      //   height: 0,
+      //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+      //   raw_log: '[]'
+      // }
+    }
+    
+    main();
+  </CodeBlock>
 </CodeGroup>
 
 ### Single Asset Provide Liquidity
@@ -207,63 +207,63 @@ public entry fun single_asset_provide_liquidity_script(
   the actual value is smaller than `min_liquidity`, the transaction will fail.
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 dex single_asset_provide_liquidity_script \
-    --args '["object:0x...", "object:0x..", "u64:100", "option<u64>:100"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 dex single_asset_provide_liquidity_script \
+        --args '["object:0x...", "object:0x..", "u64:100", "option<u64>:100"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-    bcs,
-    RESTClient,
-    MnemonicKey,
-    MsgExecute,
-    Wallet,
-} from '@initia/initia.js';
-
-async function main() {
-  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-      gasPrices: '0.015uinit',
-      gasAdjustment: '1.5',
-  });
-
-  const key = new MnemonicKey({
-      mnemonic: 'beauty sniff protect ...',
-  });
-  const wallet = new Wallet(restClient, key);
-
-  const msgs = [
-      new MsgExecute(
-      key.accAddress,
-      '0x1',
-      'dex',
-      'single_asset_provide_liquidity_script',
-      [],
-      [
-          bcs.object().serialize('0x...'), // pair object
-          bcs.object().serialize('0x...'), // provide asset metadata
-          bcs.u64().serialize(3000000000000), // provide amount
-          bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
-      ].map(v => v.toBase64())
-      ),
-  ];
-
-  // sign tx
-  const signedTx = await wallet.createAndSignTx({ msgs });
-  // send(broadcast) tx
-  restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-  // {
-  //   height: 0,
-  //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-  //   raw_log: '[]'
-  // }
-}
-
-main();
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+        bcs,
+        RESTClient,
+        MnemonicKey,
+        MsgExecute,
+        Wallet,
+    } from '@initia/initia.js';
+    
+    async function main() {
+      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+          gasPrices: '0.015uinit',
+          gasAdjustment: '1.5',
+      });
+    
+      const key = new MnemonicKey({
+          mnemonic: 'beauty sniff protect ...',
+      });
+      const wallet = new Wallet(restClient, key);
+    
+      const msgs = [
+          new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'dex',
+          'single_asset_provide_liquidity_script',
+          [],
+          [
+              bcs.object().serialize('0x...'), // pair object
+              bcs.object().serialize('0x...'), // provide asset metadata
+              bcs.u64().serialize(3000000000000), // provide amount
+              bcs.option(bcs.u64()).serialize(100000000), // min liquidity amount
+          ].map(v => v.toBase64())
+          ),
+      ];
+    
+      // sign tx
+      const signedTx = await wallet.createAndSignTx({ msgs });
+      // send(broadcast) tx
+      restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+      // {
+      //   height: 0,
+      //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+      //   raw_log: '[]'
+      // }
+    }
+    
+    main();
+  </CodeBlock>
 </CodeGroup>
 
 ## How to Withdraw Liquidity
@@ -290,63 +290,63 @@ public entry fun withdraw_liquidity_script(
   `min_coin_a_amount` or `min_coin_b_amount`, the transaction will fail.
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 dex withdraw_liquidity_script \
-    --args '["object:0x...", "u64:100", "option<u64>:100", "option<u64>:100"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 dex withdraw_liquidity_script \
+        --args '["object:0x...", "u64:100", "option<u64>:100", "option<u64>:100"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-    bcs,
-    RESTClient,
-    MnemonicKey,
-    MsgExecute,
-    Wallet,
-} from '@initia/initia.js';
-
-async function main() {
-const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-    gasPrices: '0.015uinit',
-    gasAdjustment: '1.5',
-});
-
-const key = new MnemonicKey({
-    mnemonic: 'beauty sniff protect ...',
-});
-const wallet = new Wallet(restClient, key);
-
-const msgs = [
-    new MsgExecute(
-      key.accAddress,
-      '0x1',
-      'dex',
-      'withdraw_liquidity_script',
-      [],
-      [
-          bcs.object().serialize('0x...'), // pair object
-          bcs.u64().serialize(100000000), // liquidity
-          bcs.option(bcs.u64()).serialize(100000000), // min coin a amount
-          bcs.option(bcs.u64()).serialize(100000000), // min coin b amount
-      ].map(v => v.toBase64())
-    ),
-];
-
-// sign tx
-const signedTx = await wallet.createAndSignTx({ msgs });
-// send(broadcast) tx
-restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-// {
-//   height: 0,
-//   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-//   raw_log: '[]'
-// }
-}
-
-main();
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+        bcs,
+        RESTClient,
+        MnemonicKey,
+        MsgExecute,
+        Wallet,
+    } from '@initia/initia.js';
+    
+    async function main() {
+    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.5',
+    });
+    
+    const key = new MnemonicKey({
+        mnemonic: 'beauty sniff protect ...',
+    });
+    const wallet = new Wallet(restClient, key);
+    
+    const msgs = [
+        new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'dex',
+          'withdraw_liquidity_script',
+          [],
+          [
+              bcs.object().serialize('0x...'), // pair object
+              bcs.u64().serialize(100000000), // liquidity
+              bcs.option(bcs.u64()).serialize(100000000), // min coin a amount
+              bcs.option(bcs.u64()).serialize(100000000), // min coin b amount
+          ].map(v => v.toBase64())
+        ),
+    ];
+    
+    // sign tx
+    const signedTx = await wallet.createAndSignTx({ msgs });
+    // send(broadcast) tx
+    restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+    // {
+    //   height: 0,
+    //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+    //   raw_log: '[]'
+    // }
+    }
+    
+    main();
+  </CodeBlock>
 </CodeGroup>
 
 ## How to Swap Pair
@@ -370,53 +370,53 @@ public fun get_swap_simulation(
 - `offer_amount`: Amount of offered coin.
 
 <CodeGroup>
-```bash curl
-curl -X POST "https://rest.testnet.initia.xyz/initia/move/v1/accounts/0x1/modules/dex/view_functions/get_swap_simulation" \
-    -H "accept: application/json" \
-    -H "Content-Type: application/json" \
-    -d "{ \"args\": [ \"[BCS_ENCODED_OBJECT, BCS_ENCODED_OBJECT, BCS_ENCODED_OFFER_AMOUNT]\" ]}"
+  <CodeBlock filename="curl" language="bash">
+    curl -X POST "https://rest.testnet.initia.xyz/initia/move/v1/accounts/0x1/modules/dex/view_functions/get_swap_simulation" \
+        -H "accept: application/json" \
+        -H "Content-Type: application/json" \
+        -d "{ \"args\": [ \"[BCS_ENCODED_OBJECT, BCS_ENCODED_OBJECT, BCS_ENCODED_OFFER_AMOUNT]\" ]}"
+    
+    #{
+    #  "data": "\"100\"",
+    #  "events": [],
+    #  "gas_used": "5699"
+    #}
+  </CodeBlock>
 
-#{
-#  "data": "\"100\"",
-#  "events": [],
-#  "gas_used": "5699"
-#}
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad query move view 0x1 dex get_swap_simulation \
+        --args '["object:0x...", "object:0x...", "u64:123"]' \
+        --node [rpc-url]:[rpc-port]
+    
+    # data: '"123"'
+    # events: []
+    # gas_used: "5699"
+  </CodeBlock>
 
-```bash CLI
-initiad query move view 0x1 dex get_swap_simulation \
-    --args '["object:0x...", "object:0x...", "u64:123"]' \
-    --node [rpc-url]:[rpc-port]
-
-# data: '"123"'
-# events: []
-# gas_used: "5699"
-```
-
-```ts InitiaJS
-import { RESTClient, bcs } from '@initia/initia.js';
-
-const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-        gasPrices: '0.015uinit',
-        gasAdjustment: '1.5',
-    });
-
-restClient.move
-  .view(
-      '0x1',
-      'dex',
-      'get_swap_simulation',
-      [],
-      [
-      bcs.object().serialize('0x...').toBase64(),
-      bcs.object().serialize('0x...').toBase64(),
-      bcs.u64().serialize(100).toBase64(),
-      ]
-  )
-  .then(console.log);
-
-// { data: '"100"', events: [], gas_used: '21371' }
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    import { RESTClient, bcs } from '@initia/initia.js';
+    
+    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+            gasPrices: '0.015uinit',
+            gasAdjustment: '1.5',
+        });
+    
+    restClient.move
+      .view(
+          '0x1',
+          'dex',
+          'get_swap_simulation',
+          [],
+          [
+          bcs.object().serialize('0x...').toBase64(),
+          bcs.object().serialize('0x...').toBase64(),
+          bcs.u64().serialize(100).toBase64(),
+          ]
+      )
+      .then(console.log);
+    
+    // { data: '"100"', events: [], gas_used: '21371' }
+  </CodeBlock>
 </CodeGroup>
 
 ### Swap
@@ -440,63 +440,63 @@ public entry fun swap_script(
   smaller than `min_return`, the transaction will fail.
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 dex swap_script \
-    --args '["object:0x...", "object:0x...", "u64:100", "option<u64>:100"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 dex swap_script \
+        --args '["object:0x...", "object:0x...", "u64:100", "option<u64>:100"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-    bcs,
-    RESTClient,
-    MnemonicKey,
-    MsgExecute,
-    Wallet,
-} from '@initia/initia.js';
-
-async function main() {
-    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-        gasPrices: '0.015uinit',
-        gasAdjustment: '1.5',
-    });
-
-    const key = new MnemonicKey({
-        mnemonic: 'beauty sniff protect ...',
-    });
-    const wallet = new Wallet(restClient, key);
-
-    const msgs = [
-        new MsgExecute(
-          key.accAddress,
-          '0x1',
-          'dex',
-          'swap_script',
-          [],
-          [
-              bcs.object().serialize('0x...'), // pair object
-              bcs.object().serialize('0x...'), // offer asset metadata
-              bcs.u64().serialize(100000000), // offer amount
-              bcs.option(bcs.u64()).serialize(100000000), // min return amount
-          ].map(v => v.toBase64())
-        ),
-    ];
-
-    // sign tx
-    const signedTx = await wallet.createAndSignTx({ msgs });
-    // send(broadcast) tx
-    restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-    // {
-    //   height: 0,
-    //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
-    //   raw_log: '[]'
-    // }
-}
-
-main();
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+        bcs,
+        RESTClient,
+        MnemonicKey,
+        MsgExecute,
+        Wallet,
+    } from '@initia/initia.js';
+    
+    async function main() {
+        const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+            gasPrices: '0.015uinit',
+            gasAdjustment: '1.5',
+        });
+    
+        const key = new MnemonicKey({
+            mnemonic: 'beauty sniff protect ...',
+        });
+        const wallet = new Wallet(restClient, key);
+    
+        const msgs = [
+            new MsgExecute(
+              key.accAddress,
+              '0x1',
+              'dex',
+              'swap_script',
+              [],
+              [
+                  bcs.object().serialize('0x...'), // pair object
+                  bcs.object().serialize('0x...'), // offer asset metadata
+                  bcs.u64().serialize(100000000), // offer amount
+                  bcs.option(bcs.u64()).serialize(100000000), // min return amount
+              ].map(v => v.toBase64())
+            ),
+        ];
+    
+        // sign tx
+        const signedTx = await wallet.createAndSignTx({ msgs });
+        // send(broadcast) tx
+        restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
+        // {
+        //   height: 0,
+        //   txhash: '0F2B255EE75FBA407267BB57A6FF3E3349522DA6DBB31C0356DB588CC3933F37',
+        //   raw_log: '[]'
+        // }
+    }
+    
+    main();
+  </CodeBlock>
 </CodeGroup>
 
 ## How to Delegate LP Tokens
@@ -577,32 +577,32 @@ After whitelisting the LP token, you can delegate your LP tokens to a validator.
 We can use `MsgDelegate` to delegate LP tokens.
 
 <CodeGroup>
-```bash CLI
-# initiad tx mstaking delegate [validator-addr] [amount]
-initiad tx mstaking delegate initvaloper1.... 100move/ff5c7412979 \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    # initiad tx mstaking delegate [validator-addr] [amount]
+    initiad tx mstaking delegate initvaloper1.... 100move/ff5c7412979 \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-async function delegateLP(
-    lpMetadata: string,
-    amount: number
-) {
-    // we can get lp denom from lp metadata by adding 'move/' prefix
-    // if lp metadata is ff5c7412979...
-    // then lp denom is move/ff5c7412979...
-    const msg = new MsgDelegate(
-        user.key.accAddress,                   // delegator
-        validator.key.valAddress,              // validator
-        `${amount}move/${lpMetadata}`          // lp token
-    )
-
-    const signedTx = await user.createAndSignTx({ msgs: [msg] })
-    await user.rest.tx.broadcast(signedTx).catch(console.log)
-}
-```
+  <CodeBlock filename="InitiaJS" language="ts">
+    async function delegateLP(
+        lpMetadata: string,
+        amount: number
+    ) {
+        // we can get lp denom from lp metadata by adding 'move/' prefix
+        // if lp metadata is ff5c7412979...
+        // then lp denom is move/ff5c7412979...
+        const msg = new MsgDelegate(
+            user.key.accAddress,                   // delegator
+            validator.key.valAddress,              // validator
+            `${amount}move/${lpMetadata}`          // lp token
+        )
+    
+        const signedTx = await user.createAndSignTx({ msgs: [msg] })
+        await user.rest.tx.broadcast(signedTx).catch(console.log)
+    }
+  </CodeBlock>
 </CodeGroup>
 
 ## Example Code
@@ -630,278 +630,278 @@ Also, we assume:
 - The user and validator share the same mnemonic for simplicity.
 
 <CodeGroup>
-```ts create-and-provide-liquidity.ts
-// NOTE: In this example, we use the same mnemonic for both user and validator.
-//       The reason is that we want to simplify the example. 
-//       This will make it easier to whitelist during the proposal.
-//       It takes a bit of time to whitelist, so you can skip this step 3 and do it manually.
-
-// Some possible errors: //
-location=0000000000000000000000000000000000000000000000000000000000000001::object,
-code=524289 -> The object (pair) is already created, skip step 1 //
-location=0000000000000000000000000000000000000000000000000000000000000001::object,
-code=393218 -> The object (pair) is not created yet, retry step 1
-
-import {
-  AccAddress,
-  bcs,
-  RESTClient,
-  MnemonicKey,
-  MsgDelegate,
-  MsgExecute,
-  MsgSubmitProposal,
-  MsgVote,
-  MsgWhitelist,
-  MsgWithdrawDelegatorReward,
-  Wallet,
-} from '@initia/initia.js'
-import {
-  ProposalStatus,
-  VoteOption,
-} from '@initia/initia.proto/cosmos/gov/v1/gov'
-import { delay } from 'bluebird'
-import { sha3_256 } from '@noble/hashes/sha3'
-import { concatBytes, toBytes } from '@noble/hashes/utils'
-import { toHex } from '@cosmjs/encoding'
-import { MsgUndelegate } from 'vm/move/msgs/staking'
-
-const user = new Wallet(
-  new RESTClient('http://localhost:1317', {
-    gasPrices: '0.015uinit',
-    gasAdjustment: '1.75',
-  }),
-  new MnemonicKey({
-    // TODO: put your mnemonic here
-    mnemonic: 'mimic exist actress ...',
-  }),
-)
-
-const validator = new Wallet(
-  new RESTClient('http://localhost:1317', {
-    gasPrices: '0.015uinit',
-    gasAdjustment: '1.75',
-  }),
-  new MnemonicKey({
-    // TODO: put your mnemonic here
-    mnemonic: 'mimic exist actress ...',
-  }),
-)
-
-function coinMetadata(creator: string, symbol: string) {
-  const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe
-  const addrBytes = bcs.address().serialize(creator).toBytes()
-  const seed = toBytes(symbol)
-  const bytes = new Uint8Array([
-    ...concatBytes(addrBytes, seed),
-    OBJECT_FROM_SEED_ADDRESS_SCHEME,
-  ])
-  const sum = sha3_256.create().update(bytes).digest()
-  return toHex(sum)
-}
-
-async function getLastProposalId(
-  restClient: RESTClient,
-): Promise<number> {
-  const [proposals, pagination] = await restClient.gov.proposals()
-  if (proposals.length === 0) return 0
-  return proposals[proposals.length - 1].id
-}
-
-async function getProposalStatus(
-  restClient: RESTClient,
-  proposalId: number,
-): Promise<ProposalStatus | null> {
-  const proposal = await restClient.gov.proposal(proposalId)
-  return proposal ? proposal.status : null
-}
-
-async function checkProposalPassed(
-  restClient: RESTClient,
-  proposalId: number,
-): Promise<void> {
-  for (;;) {
-    console.log(
-      `checking proposal ${proposalId} status... in ${restClient.URL}/cosmos/gov/v1/proposals/${proposalId}`,
+  <CodeBlock filename="create-and-provide-liquidity.ts" language="ts">
+    // NOTE: In this example, we use the same mnemonic for both user and validator.
+    //       The reason is that we want to simplify the example. 
+    //       This will make it easier to whitelist during the proposal.
+    //       It takes a bit of time to whitelist, so you can skip this step 3 and do it manually.
+    
+    // Some possible errors: //
+    location=0000000000000000000000000000000000000000000000000000000000000001::object,
+    code=524289 -> The object (pair) is already created, skip step 1 //
+    location=0000000000000000000000000000000000000000000000000000000000000001::object,
+    code=393218 -> The object (pair) is not created yet, retry step 1
+    
+    import {
+      AccAddress,
+      bcs,
+      RESTClient,
+      MnemonicKey,
+      MsgDelegate,
+      MsgExecute,
+      MsgSubmitProposal,
+      MsgVote,
+      MsgWhitelist,
+      MsgWithdrawDelegatorReward,
+      Wallet,
+    } from '@initia/initia.js'
+    import {
+      ProposalStatus,
+      VoteOption,
+    } from '@initia/initia.proto/cosmos/gov/v1/gov'
+    import { delay } from 'bluebird'
+    import { sha3_256 } from '@noble/hashes/sha3'
+    import { concatBytes, toBytes } from '@noble/hashes/utils'
+    import { toHex } from '@cosmjs/encoding'
+    import { MsgUndelegate } from 'vm/move/msgs/staking'
+    
+    const user = new Wallet(
+      new RESTClient('http://localhost:1317', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.75',
+      }),
+      new MnemonicKey({
+        // TODO: put your mnemonic here
+        mnemonic: 'mimic exist actress ...',
+      }),
     )
-    const status = await getProposalStatus(restClient, proposalId)
-
-    if (status === ProposalStatus.PROPOSAL_STATUS_PASSED) return
-    if (status === ProposalStatus.PROPOSAL_STATUS_REJECTED)
-      throw new Error(`proposal ${proposalId} rejected`)
-    if (status === ProposalStatus.PROPOSAL_STATUS_FAILED)
-      throw new Error(`proposal ${proposalId} failed`)
-    await delay(5_000)
-  }
-}
-
-async function provideLiquidity(
-  lp_metadata: string,
-  coin_a_amount: number,
-  coin_b_amount: number,
-  min_liquidity: number | null,
-) {
-  const msg = new MsgExecute(
-    user.key.accAddress,
-    '0x1',
-    'dex',
-    'provide_liquidity_script',
-    [],
-    [
-      bcs.string().serialize(lp_metadata).toBase64(),
-      bcs.u64().serialize(coin_a_amount).toBase64(),
-      bcs.u64().serialize(coin_b_amount).toBase64(),
-      bcs.option(bcs.u64()).serialize(min_liquidity).toBase64(),
-    ],
-  )
-
-  const signedTx = await user.createAndSignTx({ msgs: [msg] })
-  await user.rest.tx.broadcast(signedTx).catch(console.log)
-}
-
-async function createPairScript(
-  sender: Wallet,
-  name: string,
-  symbol: string,
-  swap_fee_rate: number,
-  coin_a_weight: number,
-  coin_b_weight: number,
-  coin_a_metadata: string,
-  coin_b_metadata: string,
-  coin_a_amount: number,
-  coin_b_amount: number,
-) {
-  const msg = new MsgExecute(
-    sender.key.accAddress,
-    '0x1',
-    'dex',
-    'create_pair_script',
-    [],
-    [
-      bcs.string().serialize(name).toBase64(),
-      bcs.string().serialize(symbol).toBase64(),
-      bcs.bigdecimal().serialize(swap_fee_rate).toBase64(),
-      bcs.bigdecimal().serialize(coin_a_weight).toBase64(),
-      bcs.bigdecimal().serialize(coin_b_weight).toBase64(),
-      bcs.object().serialize(coin_a_metadata).toBase64(),
-      bcs.object().serialize(coin_b_metadata).toBase64(),
-      bcs.u64().serialize(coin_a_amount).toBase64(),
-      bcs.u64().serialize(coin_b_amount).toBase64(),
-    ],
-  )
-
-  const signedTx = await sender.createAndSignTx({ msgs: [msg] })
-  await sender.rest.tx.broadcast(signedTx).catch(console.log)
-}
-
-async function whitelistLP(lpMetadata: string) {
-  const msgWhiteList = new MsgWhitelist(
-    'init10d07y265gmmuvt4z0w9aw880jnsr700j55nka3', // authority
-    AccAddress.fromHex(lpMetadata), // metadata
-    '1000000000000000000', // weight for reward (10^18)
-  )
-
-  const proposal = new MsgSubmitProposal(
-    [msgWhiteList],
-    '100000000uinit', // deposit
-    user.key.accAddress, // proposer
-    'uinit', // metadata
-    'awesome proposal', // title
-    'it is awesome', // summary
-    false, // expedited
-  )
-
-  const proposalId = (await getLastProposalId(user.rest)) + 1
-
-  // if there's only one validator, it will exceed the quorum (cause we set as
-  // user = validator)
-  const vote = new MsgVote(
-    proposalId,
-    user.key.accAddress,
-    VoteOption.VOTE_OPTION_YES,
-    '',
-  )
-  const signedTx = await user.createAndSignTx({ msgs: [proposal, vote] })
-
-  await user.rest.tx.broadcast(signedTx).catch(console.log)
-  await checkProposalPassed(user.rest, proposalId)
-}
-
-async function delegateLP(lpMetadata: string, amount: number) {
-  // we can get lp denom from lp metadata by adding 'move/' prefix
-  // if lp metadata is ff5c7412979...
-  // then lp denom is move/ff5c7412979...
-  const msg = new MsgDelegate(
-    user.key.accAddress, // delegator
-    validator.key.valAddress, // validator
-    `${amount}move/${lpMetadata}`, // lp token
-  )
-
-  const signedTx = await user.createAndSignTx({ msgs: [msg] })
-  await user.rest.tx.broadcast(signedTx).catch(console.log)
-}
-
-async function withdrawRewards() {
-  const msg = new MsgWithdrawDelegatorReward(
-    user.key.accAddress,
-    validator.key.valAddress,
-  )
-
-  const signedTx = await user.createAndSignTx({ msgs: [msg] })
-  await user.rest.tx.broadcast(signedTx).catch(console.log)
-}
-
-// NOTE: if you uncomment step 2, there will be an error
-// because it takes a bit of time to create a pair
-async function main() {
-  console.log('user:', user.key.accAddress)
-  console.log('validator:', validator.key.valAddress)
-
-  // step 1: create pair script
-  await createPairScript(
-    user,
-    'init-usdc',
-    'init-usdc',
-    0.003,
-    0.5,
-    0.5,
-    coinMetadata('0x1', 'uinit'),
-    coinMetadata('0x1', 'uusdc'),
-    100_000_000,
-    100_000_000,
-  )
-
-  const lpMetadata = coinMetadata(user.key.accAddress, 'init-usdc') //
-  // ff5c7412979176c5e7f084a6...
-  console.log('step 1 done, lp metadata:', lpMetadata)
-
-  // step 2 (optional): provide liquidity
-  // you will get LP tokens when you create a pair, so you can skip this step
-  // await provideLiquidity(
-  //   lpMetadata,
-  //   100_000_000,
-  //   100_000_000,
-  //   100_000
-  // )
-  // console.log('step 2 provide liquidity done')
-
-  // step 3: whitelist LP
-  // this step could take a while (check your 'expedited_voting_period' time in
-  // genesis.json)
-  await whitelistLP(lpMetadata)
-  console.log('step 3 whitelist done')
-
-  // step 4: delegate LP tokens to the validator
-  await delegateLP(lpMetadata, 100_000)
-  console.log('step 4 delegate done')
-
-  // step 5: withdraw rewards
-  // await withdrawRewards()
-  // console.log('step 5 withdraw done')
-}
-
-if (require.main === module) {
-  main()
-}
-
-```
+    
+    const validator = new Wallet(
+      new RESTClient('http://localhost:1317', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.75',
+      }),
+      new MnemonicKey({
+        // TODO: put your mnemonic here
+        mnemonic: 'mimic exist actress ...',
+      }),
+    )
+    
+    function coinMetadata(creator: string, symbol: string) {
+      const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe
+      const addrBytes = bcs.address().serialize(creator).toBytes()
+      const seed = toBytes(symbol)
+      const bytes = new Uint8Array([
+        ...concatBytes(addrBytes, seed),
+        OBJECT_FROM_SEED_ADDRESS_SCHEME,
+      ])
+      const sum = sha3_256.create().update(bytes).digest()
+      return toHex(sum)
+    }
+    
+    async function getLastProposalId(
+      restClient: RESTClient,
+    ): Promise<number> {
+      const [proposals, pagination] = await restClient.gov.proposals()
+      if (proposals.length === 0) return 0
+      return proposals[proposals.length - 1].id
+    }
+    
+    async function getProposalStatus(
+      restClient: RESTClient,
+      proposalId: number,
+    ): Promise<ProposalStatus | null> {
+      const proposal = await restClient.gov.proposal(proposalId)
+      return proposal ? proposal.status : null
+    }
+    
+    async function checkProposalPassed(
+      restClient: RESTClient,
+      proposalId: number,
+    ): Promise<void> {
+      for (;;) {
+        console.log(
+          `checking proposal ${proposalId} status... in ${restClient.URL}/cosmos/gov/v1/proposals/${proposalId}`,
+        )
+        const status = await getProposalStatus(restClient, proposalId)
+    
+        if (status === ProposalStatus.PROPOSAL_STATUS_PASSED) return
+        if (status === ProposalStatus.PROPOSAL_STATUS_REJECTED)
+          throw new Error(`proposal ${proposalId} rejected`)
+        if (status === ProposalStatus.PROPOSAL_STATUS_FAILED)
+          throw new Error(`proposal ${proposalId} failed`)
+        await delay(5_000)
+      }
+    }
+    
+    async function provideLiquidity(
+      lp_metadata: string,
+      coin_a_amount: number,
+      coin_b_amount: number,
+      min_liquidity: number | null,
+    ) {
+      const msg = new MsgExecute(
+        user.key.accAddress,
+        '0x1',
+        'dex',
+        'provide_liquidity_script',
+        [],
+        [
+          bcs.string().serialize(lp_metadata).toBase64(),
+          bcs.u64().serialize(coin_a_amount).toBase64(),
+          bcs.u64().serialize(coin_b_amount).toBase64(),
+          bcs.option(bcs.u64()).serialize(min_liquidity).toBase64(),
+        ],
+      )
+    
+      const signedTx = await user.createAndSignTx({ msgs: [msg] })
+      await user.rest.tx.broadcast(signedTx).catch(console.log)
+    }
+    
+    async function createPairScript(
+      sender: Wallet,
+      name: string,
+      symbol: string,
+      swap_fee_rate: number,
+      coin_a_weight: number,
+      coin_b_weight: number,
+      coin_a_metadata: string,
+      coin_b_metadata: string,
+      coin_a_amount: number,
+      coin_b_amount: number,
+    ) {
+      const msg = new MsgExecute(
+        sender.key.accAddress,
+        '0x1',
+        'dex',
+        'create_pair_script',
+        [],
+        [
+          bcs.string().serialize(name).toBase64(),
+          bcs.string().serialize(symbol).toBase64(),
+          bcs.bigdecimal().serialize(swap_fee_rate).toBase64(),
+          bcs.bigdecimal().serialize(coin_a_weight).toBase64(),
+          bcs.bigdecimal().serialize(coin_b_weight).toBase64(),
+          bcs.object().serialize(coin_a_metadata).toBase64(),
+          bcs.object().serialize(coin_b_metadata).toBase64(),
+          bcs.u64().serialize(coin_a_amount).toBase64(),
+          bcs.u64().serialize(coin_b_amount).toBase64(),
+        ],
+      )
+    
+      const signedTx = await sender.createAndSignTx({ msgs: [msg] })
+      await sender.rest.tx.broadcast(signedTx).catch(console.log)
+    }
+    
+    async function whitelistLP(lpMetadata: string) {
+      const msgWhiteList = new MsgWhitelist(
+        'init10d07y265gmmuvt4z0w9aw880jnsr700j55nka3', // authority
+        AccAddress.fromHex(lpMetadata), // metadata
+        '1000000000000000000', // weight for reward (10^18)
+      )
+    
+      const proposal = new MsgSubmitProposal(
+        [msgWhiteList],
+        '100000000uinit', // deposit
+        user.key.accAddress, // proposer
+        'uinit', // metadata
+        'awesome proposal', // title
+        'it is awesome', // summary
+        false, // expedited
+      )
+    
+      const proposalId = (await getLastProposalId(user.rest)) + 1
+    
+      // if there's only one validator, it will exceed the quorum (cause we set as
+      // user = validator)
+      const vote = new MsgVote(
+        proposalId,
+        user.key.accAddress,
+        VoteOption.VOTE_OPTION_YES,
+        '',
+      )
+      const signedTx = await user.createAndSignTx({ msgs: [proposal, vote] })
+    
+      await user.rest.tx.broadcast(signedTx).catch(console.log)
+      await checkProposalPassed(user.rest, proposalId)
+    }
+    
+    async function delegateLP(lpMetadata: string, amount: number) {
+      // we can get lp denom from lp metadata by adding 'move/' prefix
+      // if lp metadata is ff5c7412979...
+      // then lp denom is move/ff5c7412979...
+      const msg = new MsgDelegate(
+        user.key.accAddress, // delegator
+        validator.key.valAddress, // validator
+        `${amount}move/${lpMetadata}`, // lp token
+      )
+    
+      const signedTx = await user.createAndSignTx({ msgs: [msg] })
+      await user.rest.tx.broadcast(signedTx).catch(console.log)
+    }
+    
+    async function withdrawRewards() {
+      const msg = new MsgWithdrawDelegatorReward(
+        user.key.accAddress,
+        validator.key.valAddress,
+      )
+    
+      const signedTx = await user.createAndSignTx({ msgs: [msg] })
+      await user.rest.tx.broadcast(signedTx).catch(console.log)
+    }
+    
+    // NOTE: if you uncomment step 2, there will be an error
+    // because it takes a bit of time to create a pair
+    async function main() {
+      console.log('user:', user.key.accAddress)
+      console.log('validator:', validator.key.valAddress)
+    
+      // step 1: create pair script
+      await createPairScript(
+        user,
+        'init-usdc',
+        'init-usdc',
+        0.003,
+        0.5,
+        0.5,
+        coinMetadata('0x1', 'uinit'),
+        coinMetadata('0x1', 'uusdc'),
+        100_000_000,
+        100_000_000,
+      )
+    
+      const lpMetadata = coinMetadata(user.key.accAddress, 'init-usdc') //
+      // ff5c7412979176c5e7f084a6...
+      console.log('step 1 done, lp metadata:', lpMetadata)
+    
+      // step 2 (optional): provide liquidity
+      // you will get LP tokens when you create a pair, so you can skip this step
+      // await provideLiquidity(
+      //   lpMetadata,
+      //   100_000_000,
+      //   100_000_000,
+      //   100_000
+      // )
+      // console.log('step 2 provide liquidity done')
+    
+      // step 3: whitelist LP
+      // this step could take a while (check your 'expedited_voting_period' time in
+      // genesis.json)
+      await whitelistLP(lpMetadata)
+      console.log('step 3 whitelist done')
+    
+      // step 4: delegate LP tokens to the validator
+      await delegateLP(lpMetadata, 100_000)
+      console.log('step 4 delegate done')
+    
+      // step 5: withdraw rewards
+      // await withdrawRewards()
+      // console.log('step 5 withdraw done')
+    }
+    
+    if (require.main === module) {
+      main()
+    }
+    
+  </CodeBlock>
 </CodeGroup>

--- a/developers/developer-guides/integrating-initia-apps/vip/integrate-vip.mdx
+++ b/developers/developer-guides/integrating-initia-apps/vip/integrate-vip.mdx
@@ -41,32 +41,32 @@ This guide explains how a rollup can prepare for and integrate Initia's
     We then need to install the `minitiad` CLI that matches the rollup's version.
 
     <CodeGroup>
-    ```bash EVM
-    export MINIEVM_VERSION=1.1.7 # Replace with your rollup's version
+      <CodeBlock filename="EVM" language="bash">
+        export MINIEVM_VERSION=1.1.7 # Replace with your rollup's version
+        
+        git clone https://github.com/initia-labs/minievm.git
+        cd minievm
+        git checkout $MINIEVM_VERSION
+        make install
+      </CodeBlock>
 
-    git clone https://github.com/initia-labs/minievm.git
-    cd minievm
-    git checkout $MINIEVM_VERSION
-    make install
-    ```
+      <CodeBlock filename="MoveVM" language="bash">
+        export MINIMOVE_VERSION=1.0.6
+        
+        git clone https://github.com/initia-labs/minimove.git
+        cd minimove
+        git checkout $MINIMOVE_VERSION # Replace with your rollup's version
+        make install
+      </CodeBlock>
 
-    ```bash MoveVM
-    export MINIMOVE_VERSION=1.0.6
-
-    git clone https://github.com/initia-labs/minimove.git
-    cd minimove
-    git checkout $MINIMOVE_VERSION # Replace with your rollup's version
-    make install
-    ```
-
-    ```bash WasmVM
-    export MINIWASM_VERSION=1.0.6 # Replace with your rollup's version
-
-    git clone https://github.com/initia-labs/miniwasm.git
-    cd miniwasm
-    git checkout $MINIWASM_VERSION
-    make install
-    ```
+      <CodeBlock filename="WasmVM" language="bash">
+        export MINIWASM_VERSION=1.0.6 # Replace with your rollup's version
+        
+        git clone https://github.com/initia-labs/miniwasm.git
+        cd miniwasm
+        git checkout $MINIWASM_VERSION
+        make install
+      </CodeBlock>
     </CodeGroup>
 
   </Step>

--- a/developers/developer-guides/integrating-initia-apps/vip/integrate-vip.mdx
+++ b/developers/developer-guides/integrating-initia-apps/vip/integrate-vip.mdx
@@ -43,7 +43,7 @@ This guide explains how a rollup can prepare for and integrate Initia's
     <CodeGroup>
       <CodeBlock filename="EVM" language="bash">
         export MINIEVM_VERSION=1.1.7 # Replace with your rollup's version
-        
+
         git clone https://github.com/initia-labs/minievm.git
         cd minievm
         git checkout $MINIEVM_VERSION
@@ -52,7 +52,7 @@ This guide explains how a rollup can prepare for and integrate Initia's
 
       <CodeBlock filename="MoveVM" language="bash">
         export MINIMOVE_VERSION=1.0.6
-        
+
         git clone https://github.com/initia-labs/minimove.git
         cd minimove
         git checkout $MINIMOVE_VERSION # Replace with your rollup's version
@@ -61,7 +61,7 @@ This guide explains how a rollup can prepare for and integrate Initia's
 
       <CodeBlock filename="WasmVM" language="bash">
         export MINIWASM_VERSION=1.0.6 # Replace with your rollup's version
-        
+
         git clone https://github.com/initia-labs/miniwasm.git
         cd miniwasm
         git checkout $MINIWASM_VERSION

--- a/developers/developer-guides/integrating-initia-apps/vip/integrate-vip.mdx
+++ b/developers/developer-guides/integrating-initia-apps/vip/integrate-vip.mdx
@@ -40,38 +40,34 @@ This guide explains how a rollup can prepare for and integrate Initia's
 
     We then need to install the `minitiad` CLI that matches the rollup's version.
 
-    <Tabs>
-      <Tab title="EVM">
-      ```bash
-      export MINIEVM_VERSION=1.1.7 # Replace with your rollup's version
+    <CodeGroup>
+    ```bash EVM
+    export MINIEVM_VERSION=1.1.7 # Replace with your rollup's version
 
-      git clone https://github.com/initia-labs/minievm.git
-      cd minievm
-      git checkout $MINIEVM_VERSION
-      make install
-      ```
-      </Tab>
-      <Tab title="MoveVM">
-      ```bash
-      export MINIMOVE_VERSION=1.0.6
+    git clone https://github.com/initia-labs/minievm.git
+    cd minievm
+    git checkout $MINIEVM_VERSION
+    make install
+    ```
 
-      git clone https://github.com/initia-labs/minimove.git
-      cd minimove
-      git checkout $MINIMOVE_VERSION # Replace with your rollup's version
-      make install
-      ```
-      </Tab>
-      <Tab title="WasmVM">
-      ```bash
-      export MINIWASM_VERSION=1.0.6 # Replace with your rollup's version
+    ```bash MoveVM
+    export MINIMOVE_VERSION=1.0.6
 
-      git clone https://github.com/initia-labs/miniwasm.git
-      cd miniwasm
-      git checkout $MINIWASM_VERSION
-      make install
-      ```
-      </Tab>
-    </Tabs>
+    git clone https://github.com/initia-labs/minimove.git
+    cd minimove
+    git checkout $MINIMOVE_VERSION # Replace with your rollup's version
+    make install
+    ```
+
+    ```bash WasmVM
+    export MINIWASM_VERSION=1.0.6 # Replace with your rollup's version
+
+    git clone https://github.com/initia-labs/miniwasm.git
+    cd miniwasm
+    git checkout $MINIWASM_VERSION
+    make install
+    ```
+    </CodeGroup>
 
   </Step>
   <Step title="Create an operator and VIP contract deployer account">

--- a/developers/developer-guides/integrating-initia-apps/vip/manage-operator-settings.mdx
+++ b/developers/developer-guides/integrating-initia-apps/vip/manage-operator-settings.mdx
@@ -19,43 +19,40 @@ The bridge ID uniquely identifies your rollup bridge and can be retrieved from
 `${REST_URL}/opinit/opchild/v1/bridge_info`.
 
 <CodeGroup>
-```bash Mainnet (interwoven-1)
-export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
-export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
-export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8' 
-export RPC_URL='https://rpc.initia.xyz'
-export CHAIN_ID='interwoven-1'
+  <CodeBlock filename="Mainnet (interwoven-1)" language="bash">
+    export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+    export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
+    export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
+    export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8' 
+    export RPC_URL='https://rpc.initia.xyz'
+    export CHAIN_ID='interwoven-1'
+    
+    initiad tx move execute-json $VIP_CONTRACT vip update_operator \
+        --args '["'${BRIDGE_ID}'", "'${NEW_OPERATOR_ADDRESS}'"]' \
+        --from $OPERATOR_KEY_NAME \
+        --node $RPC_URL \
+        --chain-id $CHAIN_ID \
+        --gas-prices 0.015uinit \
+        --gas auto
+    
+  </CodeBlock>
 
-initiad tx move execute-json
-$VIP_CONTRACT vip update_operator \
-    --args '["'${BRIDGE_ID}'",
-"'${NEW_OPERATOR_ADDRESS}'"]' \
- --from $OPERATOR_KEY_NAME \
- --node $RPC_URL \
- --chain-id $CHAIN_ID \
- --gas-prices 0.015uinit \
- --gas auto
-
-````
-
-```bash Testnet (initiation-2)
-export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
-export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
-export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
-export RPC_URL='https://rpc.testnet.initia.xyz'
-export CHAIN_ID='initiation-2'
-
-initiad tx move execute-json $VIP_CONTRACT vip update_operator \
-    --args '["'${BRIDGE_ID}'", "'${NEW_OPERATOR_ADDRESS}'"]' \
-    --from $OPERATOR_KEY_NAME \
-    --node $RPC_URL \
-    --chain-id $CHAIN_ID \
-    --gas-prices 0.015uinit \
-    --gas auto
-````
-
+  <CodeBlock filename="Testnet (initiation-2)" language="bash">
+    export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+    export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
+    export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
+    export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
+    export RPC_URL='https://rpc.testnet.initia.xyz'
+    export CHAIN_ID='initiation-2'
+    
+    initiad tx move execute-json $VIP_CONTRACT vip update_operator \
+        --args '["'${BRIDGE_ID}'", "'${NEW_OPERATOR_ADDRESS}'"]' \
+        --from $OPERATOR_KEY_NAME \
+        --node $RPC_URL \
+        --chain-id $CHAIN_ID \
+        --gas-prices 0.015uinit \
+        --gas auto
+  </CodeBlock>
 </CodeGroup>
 
 ## Updating Operator Commission
@@ -78,43 +75,40 @@ rollup is delisted and later relisted, set the version to the previous value
 plus 1.
 
 <CodeGroup>
-```bash Mainnet (interwoven-1)
-export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-export VERSION=1                            # Use 1 unless your rollup has been delisted before
-export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
-export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
-export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8'
-export RPC_URL='https://rpc.initia.xyz'
-export CHAIN_ID='interwoven-1'
+  <CodeBlock filename="Mainnet (interwoven-1)" language="bash">
+    export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+    export VERSION=1                            # Use 1 unless your rollup has been delisted before
+    export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
+    export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
+    export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8'
+    export RPC_URL='https://rpc.initia.xyz'
+    export CHAIN_ID='interwoven-1'
+    
+    initiad tx move execute-json $VIP_CONTRACT vip update_operator_commission \
+        --args '["'${BRIDGE_ID}'", "'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
+        --from $OPERATOR_KEY_NAME \
+        --node $RPC_URL \
+        --chain-id $CHAIN_ID \
+        --gas-prices 0.015uinit \
+        --gas auto
+    
+  </CodeBlock>
 
-initiad tx move execute-json
-$VIP_CONTRACT vip update_operator_commission \
-    --args '["'${BRIDGE_ID}'",
-"'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
- --from $OPERATOR_KEY_NAME \
- --node $RPC_URL \
- --chain-id $CHAIN_ID \
- --gas-prices 0.015uinit \
- --gas auto
-
-````
-
-```bash Testnet (initiation-2)
-export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-export VERSION=1                            # Use 1 unless your rollup has been delisted before
-export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
-export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
-export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
-export RPC_URL='https://rpc.testnet.initia.xyz'
-export CHAIN_ID='initiation-2'
-
-initiad tx move execute-json $VIP_CONTRACT vip update_operator_commission \
-    --args '["'${BRIDGE_ID}'", "'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
-    --from $OPERATOR_KEY_NAME \
-    --node $RPC_URL \
-    --chain-id $CHAIN_ID \
-    --gas-prices 0.015uinit \
-    --gas auto
-````
-
+  <CodeBlock filename="Testnet (initiation-2)" language="bash">
+    export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+    export VERSION=1                            # Use 1 unless your rollup has been delisted before
+    export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
+    export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
+    export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
+    export RPC_URL='https://rpc.testnet.initia.xyz'
+    export CHAIN_ID='initiation-2'
+    
+    initiad tx move execute-json $VIP_CONTRACT vip update_operator_commission \
+        --args '["'${BRIDGE_ID}'", "'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
+        --from $OPERATOR_KEY_NAME \
+        --node $RPC_URL \
+        --chain-id $CHAIN_ID \
+        --gas-prices 0.015uinit \
+        --gas auto
+  </CodeBlock>
 </CodeGroup>

--- a/developers/developer-guides/integrating-initia-apps/vip/manage-operator-settings.mdx
+++ b/developers/developer-guides/integrating-initia-apps/vip/manage-operator-settings.mdx
@@ -18,45 +18,45 @@ pass two arguments in order: the rollup bridge ID and the new operator address.
 The bridge ID uniquely identifies your rollup bridge and can be retrieved from
 `${REST_URL}/opinit/opchild/v1/bridge_info`.
 
-<Tabs>
-    <Tab title="Mainnet (interwoven-1)">
-        ```bash
-        export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-        export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
-        export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
-        export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8' 
-        export RPC_URL='https://rpc.initia.xyz'
-        export CHAIN_ID='interwoven-1'
+<CodeGroup>
+```bash Mainnet (interwoven-1)
+export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
+export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
+export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8' 
+export RPC_URL='https://rpc.initia.xyz'
+export CHAIN_ID='interwoven-1'
 
-        initiad tx move execute-json $VIP_CONTRACT vip update_operator \
-            --args '["'${BRIDGE_ID}'", "'${NEW_OPERATOR_ADDRESS}'"]' \
-            --from $OPERATOR_KEY_NAME \
-            --node $RPC_URL \
-            --chain-id $CHAIN_ID \
-            --gas-prices 0.015uinit \
-            --gas auto
-        ```
-    </Tab>
-    <Tab title="Testnet (initiation-2)">
-        ```bash
-        export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-        export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
-        export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
-        export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
-        export RPC_URL='https://rpc.testnet.initia.xyz'
-        export CHAIN_ID='initiation-2'
+initiad tx move execute-json
+$VIP_CONTRACT vip update_operator \
+    --args '["'${BRIDGE_ID}'",
+"'${NEW_OPERATOR_ADDRESS}'"]' \
+ --from $OPERATOR_KEY_NAME \
+ --node $RPC_URL \
+ --chain-id $CHAIN_ID \
+ --gas-prices 0.015uinit \
+ --gas auto
 
-        initiad tx move execute-json $VIP_CONTRACT vip update_operator \
-            --args '["'${BRIDGE_ID}'", "'${NEW_OPERATOR_ADDRESS}'"]' \
-            --from $OPERATOR_KEY_NAME \
-            --node $RPC_URL \
-            --chain-id $CHAIN_ID \
-            --gas-prices 0.015uinit \
-            --gas auto
-        ```
-    </Tab>
+````
 
-</Tabs>
+```bash Testnet (initiation-2)
+export BRIDGE_ID=29                                                      # Replace with your rollup bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+export NEW_OPERATOR_ADDRESS=init14zmga05vl324ddaw7wqwdqt9pcvjeeyae3jn2k  # Replace with the new operator address
+export OPERATOR_KEY_NAME=operator                                        # Replace with your operator key. Check `initiad keys list` for the list of your keys
+export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
+export RPC_URL='https://rpc.testnet.initia.xyz'
+export CHAIN_ID='initiation-2'
+
+initiad tx move execute-json $VIP_CONTRACT vip update_operator \
+    --args '["'${BRIDGE_ID}'", "'${NEW_OPERATOR_ADDRESS}'"]' \
+    --from $OPERATOR_KEY_NAME \
+    --node $RPC_URL \
+    --chain-id $CHAIN_ID \
+    --gas-prices 0.015uinit \
+    --gas auto
+````
+
+</CodeGroup>
 
 ## Updating Operator Commission
 
@@ -77,44 +77,44 @@ Use version value `1` when the rollup is listed for the first time. If the
 rollup is delisted and later relisted, set the version to the previous value
 plus 1.
 
-<Tabs>
-    <Tab title="Mainnet (interwoven-1)">
-        ```bash
-        export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-        export VERSION=1                            # Use 1 unless your rollup has been delisted before
-        export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
-        export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
-        export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8'
-        export RPC_URL='https://rpc.initia.xyz'
-        export CHAIN_ID='interwoven-1'
+<CodeGroup>
+```bash Mainnet (interwoven-1)
+export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+export VERSION=1                            # Use 1 unless your rollup has been delisted before
+export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
+export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
+export VIP_CONTRACT='init182yxkv4gqfvz7tjyde6dfgjdr4ldqxklgmf23aju2u3cslnss7ys6dy6w8'
+export RPC_URL='https://rpc.initia.xyz'
+export CHAIN_ID='interwoven-1'
 
-        initiad tx move execute-json $VIP_CONTRACT vip update_operator_commission \
-            --args '["'${BRIDGE_ID}'", "'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
-            --from $OPERATOR_KEY_NAME \
-            --node $RPC_URL \
-            --chain-id $CHAIN_ID \
-            --gas-prices 0.015uinit \
-            --gas auto
-        ```
-    </Tab>
-    <Tab title="Testnet (initiation-2)">
-        ```bash
-        export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
-        export VERSION=1                            # Use 1 unless your rollup has been delisted before
-        export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
-        export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
-        export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
-        export RPC_URL='https://rpc.testnet.initia.xyz'
-        export CHAIN_ID='initiation-2'
+initiad tx move execute-json
+$VIP_CONTRACT vip update_operator_commission \
+    --args '["'${BRIDGE_ID}'",
+"'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
+ --from $OPERATOR_KEY_NAME \
+ --node $RPC_URL \
+ --chain-id $CHAIN_ID \
+ --gas-prices 0.015uinit \
+ --gas auto
 
-        initiad tx move execute-json $VIP_CONTRACT vip update_operator_commission \
-            --args '["'${BRIDGE_ID}'", "'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
-            --from $OPERATOR_KEY_NAME \
-            --node $RPC_URL \
-            --chain-id $CHAIN_ID \
-            --gas-prices 0.015uinit \
-            --gas auto
-        ```
-    </Tab>
+````
 
-</Tabs>
+```bash Testnet (initiation-2)
+export BRIDGE_ID=29                         # Replace with your actual bridge ID. You can get it from `${REST_URL}/opinit/opchild/v1/bridge_info`
+export VERSION=1                            # Use 1 unless your rollup has been delisted before
+export NEW_COMMISSION_RATE=0.05             # Replace with the new commission rate (e.g., 0.05 for 5%)
+export OPERATOR_KEY_NAME=operator           # Replace with your operator key name. Check `initiad keys list` for the list of your keys
+export VIP_CONTRACT='init1u4wvsgl0ksgma40w6fdv55nhy2d9f332kdmfqp0cdnzyhsxquk4swhuwfz'
+export RPC_URL='https://rpc.testnet.initia.xyz'
+export CHAIN_ID='initiation-2'
+
+initiad tx move execute-json $VIP_CONTRACT vip update_operator_commission \
+    --args '["'${BRIDGE_ID}'", "'${VERSION}'", "'${NEW_COMMISSION_RATE}'"]' \
+    --from $OPERATOR_KEY_NAME \
+    --node $RPC_URL \
+    --chain-id $CHAIN_ID \
+    --gas-prices 0.015uinit \
+    --gas auto
+````
+
+</CodeGroup>

--- a/developers/developer-guides/tools/clis/initiad-cli/introduction.mdx
+++ b/developers/developer-guides/tools/clis/initiad-cli/introduction.mdx
@@ -58,26 +58,26 @@ cd initia
 Fetch the current network version and checkout the corresponding tag. Choose the network that matches your intended use case:
 
 <CodeGroup>
-```bash Mainnet
-# Get the current mainnet version and checkout
-export VERSION=$(curl -s https://rest.initia.xyz/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
-echo "Checking out version: $VERSION"
-git checkout $VERSION
-```
+  <CodeBlock filename="Mainnet" language="bash">
+    # Get the current mainnet version and checkout
+    export VERSION=$(curl -s https://rest.initia.xyz/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+    echo "Checking out version: $VERSION"
+    git checkout $VERSION
+  </CodeBlock>
 
-```bash Testnet
-# Get the current testnet version and checkout
-export VERSION=$(curl -s https://rest.testnet.initia.xyz/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
-echo "Checking out version: $VERSION"
-git checkout $VERSION
-```
+  <CodeBlock filename="Testnet" language="bash">
+    # Get the current testnet version and checkout
+    export VERSION=$(curl -s https://rest.testnet.initia.xyz/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+    echo "Checking out version: $VERSION"
+    git checkout $VERSION
+  </CodeBlock>
 
-```bash Manual
-# Manually set a specific version and checkout
-export VERSION=v0.5.7
-echo "Checking out version: $VERSION"
-git checkout $VERSION
-```
+  <CodeBlock filename="Manual" language="bash">
+    # Manually set a specific version and checkout
+    export VERSION=v0.5.7
+    echo "Checking out version: $VERSION"
+    git checkout $VERSION
+  </CodeBlock>
 </CodeGroup>
 
 <Warning>
@@ -132,21 +132,20 @@ By default, initiad connects to the Initia mainnet. You can configure it to
 connect to different networks:
 
 <CodeGroup>
-```bash Mainnet
-initiad config chain-id initia-1
-initiad config node https://rpc.initia.xyz:443
-```
+  <CodeBlock filename="Mainnet" language="bash">
+    initiad config chain-id initia-1
+    initiad config node https://rpc.initia.xyz:443
+  </CodeBlock>
 
-```bash Testnet
-initiad config chain-id initiation-1
-initiad config node https://rpc.testnet.initia.xyz:443
-```
+  <CodeBlock filename="Testnet" language="bash">
+    initiad config chain-id initiation-1
+    initiad config node https://rpc.testnet.initia.xyz:443
+  </CodeBlock>
 
-```bash Local Node
-initiad config chain-id local-initia
-initiad config node tcp://localhost:26657
-```
-
+  <CodeBlock filename="Local Node" language="bash">
+    initiad config chain-id local-initia
+    initiad config node tcp://localhost:26657
+  </CodeBlock>
 </CodeGroup>
 
 ## Next Steps

--- a/developers/developer-guides/tools/clis/initiad-cli/introduction.mdx
+++ b/developers/developer-guides/tools/clis/initiad-cli/introduction.mdx
@@ -57,34 +57,28 @@ cd initia
 <Step title="Get Version and Checkout">
 Fetch the current network version and checkout the corresponding tag. Choose the network that matches your intended use case:
 
-<Tabs>
-<Tab title="Mainnet">
-```bash
+<CodeGroup>
+```bash Mainnet
 # Get the current mainnet version and checkout
 export VERSION=$(curl -s https://rest.initia.xyz/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
 echo "Checking out version: $VERSION"
 git checkout $VERSION
 ```
-</Tab>
 
-<Tab title="Testnet">
-```bash
+```bash Testnet
 # Get the current testnet version and checkout
 export VERSION=$(curl -s https://rest.testnet.initia.xyz/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
 echo "Checking out version: $VERSION"
 git checkout $VERSION
 ```
-</Tab>
 
-<Tab title="Manual">
-```bash
+```bash Manual
 # Manually set a specific version and checkout
 export VERSION=v0.5.7
 echo "Checking out version: $VERSION"
 git checkout $VERSION
 ```
-</Tab>
-</Tabs>
+</CodeGroup>
 
 <Warning>
   Always use a specific version tag rather than the main branch for production
@@ -137,28 +131,23 @@ initiad --help
 By default, initiad connects to the Initia mainnet. You can configure it to
 connect to different networks:
 
-<Tabs>
-<Tab title="Mainnet">
-```bash
+<CodeGroup>
+```bash Mainnet
 initiad config chain-id initia-1
 initiad config node https://rpc.initia.xyz:443
 ```
-</Tab>
 
-<Tab title="Testnet">
-```bash
+```bash Testnet
 initiad config chain-id initiation-1
 initiad config node https://rpc.testnet.initia.xyz:443
 ```
-</Tab>
 
-<Tab title="Local Node">
-```bash
+```bash Local Node
 initiad config chain-id local-initia
 initiad config node tcp://localhost:26657
 ```
-</Tab>
-</Tabs>
+
+</CodeGroup>
 
 ## Next Steps
 

--- a/developers/developer-guides/tools/clis/minitiad-cli/introduction.mdx
+++ b/developers/developer-guides/tools/clis/minitiad-cli/introduction.mdx
@@ -66,28 +66,22 @@ Before installing minitiad, ensure you have the following requirements:
 <Step title="Clone the Repository">
 First, clone the appropriate repository based on your rollup's VM type:
 
-<Tabs>
-<Tab title="Move">
-```bash
+<CodeGroup>
+```bash Move
 git clone https://github.com/initia-labs/minimove.git
 cd minimove
 ```
-</Tab>
 
-<Tab title="Wasm">
-```bash
+```bash Wasm
 git clone https://github.com/initia-labs/miniwasm.git
 cd miniwasm
 ```
-</Tab>
 
-<Tab title="EVM">
-```bash
+```bash EVM
 git clone https://github.com/initia-labs/minievm.git
 cd minievm
 ```
-</Tab>
-</Tabs>
+</CodeGroup>
 
 <Note>
 Make sure to choose the correct repository that matches your target rollup chain's VM type.
@@ -97,9 +91,8 @@ Make sure to choose the correct repository that matches your target rollup chain
 <Step title="Get Version and Checkout">
 Fetch the current network version and checkout the corresponding tag. Set your rollup chain endpoints first:
 
-<Tabs>
-<Tab title="Using Chain Endpoints">
-```bash
+<CodeGroup>
+```bash Using Chain Endpoints
 # Set your rollup chain endpoints (replace with your specific chain)
 export CHAIN_REST_ENDPOINT="https://rest.your-rollup-chain.com"
 export CHAIN_RPC_ENDPOINT="https://rpc.your-rollup-chain.com"
@@ -110,17 +103,14 @@ export VERSION=$(curl -s $CHAIN_REST_ENDPOINT/cosmos/base/tendermint/v1beta1/nod
 echo "Checking out version: $VERSION"
 git checkout $VERSION
 ```
-</Tab>
 
-<Tab title="Manual Version">
-```bash
+```bash Manual Version
 # Manually set a specific version and checkout
 export VERSION=v0.5.7
 echo "Checking out version: $VERSION"
 git checkout $VERSION
 ```
-</Tab>
-</Tabs>
+</CodeGroup>
 
 <Warning>
   Always use a specific version tag rather than the main branch for production

--- a/developers/developer-guides/tools/clis/minitiad-cli/introduction.mdx
+++ b/developers/developer-guides/tools/clis/minitiad-cli/introduction.mdx
@@ -67,20 +67,20 @@ Before installing minitiad, ensure you have the following requirements:
 First, clone the appropriate repository based on your rollup's VM type:
 
 <CodeGroup>
-```bash Move
-git clone https://github.com/initia-labs/minimove.git
-cd minimove
-```
+  <CodeBlock filename="Move" language="bash">
+    git clone https://github.com/initia-labs/minimove.git
+    cd minimove
+  </CodeBlock>
 
-```bash Wasm
-git clone https://github.com/initia-labs/miniwasm.git
-cd miniwasm
-```
+  <CodeBlock filename="Wasm" language="bash">
+    git clone https://github.com/initia-labs/miniwasm.git
+    cd miniwasm
+  </CodeBlock>
 
-```bash EVM
-git clone https://github.com/initia-labs/minievm.git
-cd minievm
-```
+  <CodeBlock filename="EVM" language="bash">
+    git clone https://github.com/initia-labs/minievm.git
+    cd minievm
+  </CodeBlock>
 </CodeGroup>
 
 <Note>
@@ -92,24 +92,24 @@ Make sure to choose the correct repository that matches your target rollup chain
 Fetch the current network version and checkout the corresponding tag. Set your rollup chain endpoints first:
 
 <CodeGroup>
-```bash Using Chain Endpoints
-# Set your rollup chain endpoints (replace with your specific chain)
-export CHAIN_REST_ENDPOINT="https://rest.your-rollup-chain.com"
-export CHAIN_RPC_ENDPOINT="https://rpc.your-rollup-chain.com"
+  <CodeBlock filename="Using Chain Endpoints" language="bash">
+    # Set your rollup chain endpoints (replace with your specific chain)
+    export CHAIN_REST_ENDPOINT="https://rest.your-rollup-chain.com"
+    export CHAIN_RPC_ENDPOINT="https://rpc.your-rollup-chain.com"
+    
+    # Get the current rollup version and checkout
+    
+    export VERSION=$(curl -s $CHAIN_REST_ENDPOINT/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+    echo "Checking out version: $VERSION"
+    git checkout $VERSION
+  </CodeBlock>
 
-# Get the current rollup version and checkout
-
-export VERSION=$(curl -s $CHAIN_REST_ENDPOINT/cosmos/base/tendermint/v1beta1/node_info | jq -r '.application_version.version' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
-echo "Checking out version: $VERSION"
-git checkout $VERSION
-```
-
-```bash Manual Version
-# Manually set a specific version and checkout
-export VERSION=v0.5.7
-echo "Checking out version: $VERSION"
-git checkout $VERSION
-```
+  <CodeBlock filename="Manual Version" language="bash">
+    # Manually set a specific version and checkout
+    export VERSION=v0.5.7
+    echo "Checking out version: $VERSION"
+    git checkout $VERSION
+  </CodeBlock>
 </CodeGroup>
 
 <Warning>

--- a/developers/developer-guides/vm-specific-tutorials/movevm/creating-move-coin.mdx
+++ b/developers/developer-guides/vm-specific-tutorials/movevm/creating-move-coin.mdx
@@ -25,68 +25,67 @@ public entry fun initialize(
 ```
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 managed_coin initialize \
-    --args '["option<u128>:null", "string:my_coin", "string:MYCOIN", "u8:6", "string:ICON_URI", "string:PROJECT_URI"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 managed_coin initialize \
+        --args '["option<u128>:null", "string:my_coin", "string:MYCOIN", "u8:6", "string:ICON_URI", "string:PROJECT_URI"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-  bcs,
-  RESTClient,
-  MnemonicKey,
-  MsgExecute,
-  Wallet,
-} from '@initia/initia.js'
-
-async function createCoin() {
-  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-    gasPrices: '0.015uinit',
-    gasAdjustment: '1.5',
-  })
-
-  const key = new MnemonicKey({
-    mnemonic: 'beauty sniff protect ...',
-  })
-  const wallet = new Wallet(restClient, key)
-
-  const msgs = [
-    new MsgExecute(
-      key.accAddress,
-      '0x1',
-      'managed_coin',
-      'initialize',
-      [],
-      [
-        // max supply, if you want to set max supply, insert number instead of null
-        bcs.option(bcs.u128()).serialize(null).toBase64(),
-        bcs.string().serialize('my_coin').toBase64(), // name
-        bcs.string().serialize('MYCOIN').toBase64(), // symbol
-        // decimal point (raw value 1 consider to 10 ** (- decimalPoint))
-        bcs.u8().serialize(6).toBase64(),
-        bcs.string().serialize('').toBase64(), // icon uri
-        bcs.string().serialize('').toBase64(), // project uri
-      ],
-    ),
-  ]
-
-  // sign tx
-  const signedTx = await wallet.createAndSignTx({ msgs })
-  // send(broadcast) tx
-  restClient.tx.broadcastSync(signedTx).then((res) => console.log(res))
-  // {
-  //   height: 0,
-  //   txhash: '40E0D5633D37E207B2463D275F5B479FC67D545B666C37DC7B121ED551FA18FC',
-  //   raw_log: '[]'
-  // }
-}
-
-createCoin()
-```
-
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+      bcs,
+      RESTClient,
+      MnemonicKey,
+      MsgExecute,
+      Wallet,
+    } from '@initia/initia.js'
+    
+    async function createCoin() {
+      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.5',
+      })
+    
+      const key = new MnemonicKey({
+        mnemonic: 'beauty sniff protect ...',
+      })
+      const wallet = new Wallet(restClient, key)
+    
+      const msgs = [
+        new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'managed_coin',
+          'initialize',
+          [],
+          [
+            // max supply, if you want to set max supply, insert number instead of null
+            bcs.option(bcs.u128()).serialize(null).toBase64(),
+            bcs.string().serialize('my_coin').toBase64(), // name
+            bcs.string().serialize('MYCOIN').toBase64(), // symbol
+            // decimal point (raw value 1 consider to 10 ** (- decimalPoint))
+            bcs.u8().serialize(6).toBase64(),
+            bcs.string().serialize('').toBase64(), // icon uri
+            bcs.string().serialize('').toBase64(), // project uri
+          ],
+        ),
+      ]
+    
+      // sign tx
+      const signedTx = await wallet.createAndSignTx({ msgs })
+      // send(broadcast) tx
+      restClient.tx.broadcastSync(signedTx).then((res) => console.log(res))
+      // {
+      //   height: 0,
+      //   txhash: '40E0D5633D37E207B2463D275F5B479FC67D545B666C37DC7B121ED551FA18FC',
+      //   raw_log: '[]'
+      // }
+    }
+    
+    createCoin()
+  </CodeBlock>
 </CodeGroup>
 
 # Step 2: Mint Coin
@@ -109,138 +108,136 @@ through the `0x1::coin::metadata` view function or by using
 ## Obtaining Metadata
 
 <CodeGroup>
-```bash CLI
-initiad query move view 0x1 coin metadata \
-    --args '["address:0x...", "string:MYCOIN"]' \
-    --node [rpc-url]:[rpc-port]
+  <CodeBlock filename="CLI" language="bash">
+    initiad query move view 0x1 coin metadata \
+        --args '["address:0x...", "string:MYCOIN"]' \
+        --node [rpc-url]:[rpc-port]
+    
+    # data: '"0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb"'
+    
+  </CodeBlock>
 
-# data: '"0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb"'
-
-````
-
-```ts InitiaJS
-import { bcs, RESTClient, MnemonicKey } from '@initia/initia.js';
-import * as crypto from 'crypto';
-
-async function getCoinMetadata() {
-    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-        gasPrices: '0.015uinit',
-        gasAdjustment: '1.5',
-    });
-
-    const key = new MnemonicKey({
-        mnemonic: 'beauty sniff protect ...',
-    });
-
-    // Method 1: use view function
-    restClient.move
-        .viewFunction(
-        '0x1',
-        'coin',
-        'metadata',
-        [],
-        [
-            bcs.address().serialize(key.accAddress).toBase64(),
-            bcs.string().serialize('MYCOIN').toBase64(),
-        ]
-        )
-        .then(console.log);
-    // 0xcf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
-
-    // Method 2: use sha3-256
-    console.log(coinMetadata(key.accAddress, 'MYCOIN'));
-    // cf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
-}
-
-getCoinMetadata();
-
-function coinMetadata(creator: string, symbol: string): string {
-    const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe;
-    const addrBytes = bcs.address().serialize(creator).toBytes();
-    const seed = Buffer.from(symbol, 'ascii');
-    const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME];
-    const hash = crypto.createHash('SHA3-256');
-    const digest = hash.update(Buffer.from(bytes)).digest();
-    return digest.toString('hex');
-}
-````
-
+  <CodeBlock filename="InitiaJS" language="ts">
+    import { bcs, RESTClient, MnemonicKey } from '@initia/initia.js';
+    import * as crypto from 'crypto';
+    
+    async function getCoinMetadata() {
+        const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+            gasPrices: '0.015uinit',
+            gasAdjustment: '1.5',
+        });
+    
+        const key = new MnemonicKey({
+            mnemonic: 'beauty sniff protect ...',
+        });
+    
+        // Method 1: use view function
+        restClient.move
+            .viewFunction(
+            '0x1',
+            'coin',
+            'metadata',
+            [],
+            [
+                bcs.address().serialize(key.accAddress).toBase64(),
+                bcs.string().serialize('MYCOIN').toBase64(),
+            ]
+            )
+            .then(console.log);
+        // 0xcf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
+    
+        // Method 2: use sha3-256
+        console.log(coinMetadata(key.accAddress, 'MYCOIN'));
+        // cf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
+    }
+    
+    getCoinMetadata();
+    
+    function coinMetadata(creator: string, symbol: string): string {
+        const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe;
+        const addrBytes = bcs.address().serialize(creator).toBytes();
+        const seed = Buffer.from(symbol, 'ascii');
+        const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME];
+        const hash = crypto.createHash('SHA3-256');
+        const digest = hash.update(Buffer.from(bytes)).digest();
+        return digest.toString('hex');
+    }
+  </CodeBlock>
 </CodeGroup>
 
 ## Minting Coins
 
 <CodeGroup>
-```bash CLI
-initiad tx move execute 0x1 managed_coin mint \
-    --args '["address:0x...", "object:0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb", "u64:100000000"]' \
-    --from [key-name] \
-    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-```
+  <CodeBlock filename="CLI" language="bash">
+    initiad tx move execute 0x1 managed_coin mint \
+        --args '["address:0x...", "object:0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb", "u64:100000000"]' \
+        --from [key-name] \
+        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+  </CodeBlock>
 
-```ts InitiaJS
-import {
-  bcs,
-  RESTClient,
-  MnemonicKey,
-  MsgExecute,
-  Wallet,
-} from '@initia/initia.js'
-import * as crypto from 'crypto'
-
-async function mintCoin() {
-  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-    gasPrices: '0.015uinit',
-    gasAdjustment: '1.5',
-  })
-
-  const key = new MnemonicKey({
-    mnemonic: 'beauty sniff protect ...',
-  })
-  const wallet = new Wallet(restClient, key)
-
-  const msgs = [
-    new MsgExecute(
-      key.accAddress,
-      '0x1',
-      'managed_coin',
-      'mint',
-      [],
-      [
-        bcs.address().serialize(key.accAddress).toBase64(),
-        bcs
-          .object()
-          .serialize(coinMetadata(key.accAddress, 'MYCOIN'))
-          .toBase64(),
-        bcs.u64().serialize(100000000).toBase64(),
-      ],
-    ),
-  ]
-
-  // sign tx
-  const signedTx = await wallet.createAndSignTx({ msgs })
-  // send(broadcast) tx
-  restClient.tx.broadcastSync(signedTx).then((res) => console.log(res))
-  // {
-  //   height: 0,
-  //   txhash: '593827F58F3E811686EC6FFDAD2E27E91DA707965F0FF33093DC071D47A46786',
-  //   raw_log: '[]'
-  // }
-}
-
-mintCoin()
-
-function coinMetadata(creator: string, symbol: string): string {
-  const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe
-  const addrBytes = bcs.address().serialize(creator).toBytes()
-  const seed = Buffer.from(symbol, 'ascii')
-  const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME]
-  const hash = crypto.createHash('SHA3-256')
-  const digest = hash.update(Buffer.from(bytes)).digest()
-  return digest.toString('hex')
-}
-```
-
+  <CodeBlock filename="InitiaJS" language="ts">
+    import {
+      bcs,
+      RESTClient,
+      MnemonicKey,
+      MsgExecute,
+      Wallet,
+    } from '@initia/initia.js'
+    import * as crypto from 'crypto'
+    
+    async function mintCoin() {
+      const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.5',
+      })
+    
+      const key = new MnemonicKey({
+        mnemonic: 'beauty sniff protect ...',
+      })
+      const wallet = new Wallet(restClient, key)
+    
+      const msgs = [
+        new MsgExecute(
+          key.accAddress,
+          '0x1',
+          'managed_coin',
+          'mint',
+          [],
+          [
+            bcs.address().serialize(key.accAddress).toBase64(),
+            bcs
+              .object()
+              .serialize(coinMetadata(key.accAddress, 'MYCOIN'))
+              .toBase64(),
+            bcs.u64().serialize(100000000).toBase64(),
+          ],
+        ),
+      ]
+    
+      // sign tx
+      const signedTx = await wallet.createAndSignTx({ msgs })
+      // send(broadcast) tx
+      restClient.tx.broadcastSync(signedTx).then((res) => console.log(res))
+      // {
+      //   height: 0,
+      //   txhash: '593827F58F3E811686EC6FFDAD2E27E91DA707965F0FF33093DC071D47A46786',
+      //   raw_log: '[]'
+      // }
+    }
+    
+    mintCoin()
+    
+    function coinMetadata(creator: string, symbol: string): string {
+      const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe
+      const addrBytes = bcs.address().serialize(creator).toBytes()
+      const seed = Buffer.from(symbol, 'ascii')
+      const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME]
+      const hash = crypto.createHash('SHA3-256')
+      const digest = hash.update(Buffer.from(bytes)).digest()
+      return digest.toString('hex')
+    }
+  </CodeBlock>
 </CodeGroup>
 
 After minting, you can check the balances to verify the minting process.

--- a/developers/developer-guides/vm-specific-tutorials/movevm/creating-move-coin.mdx
+++ b/developers/developer-guides/vm-specific-tutorials/movevm/creating-move-coin.mdx
@@ -24,73 +24,70 @@ public entry fun initialize(
 )
 ```
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad tx move execute 0x1 managed_coin initialize \
-        --args '["option<u128>:null", "string:my_coin", "string:MYCOIN", "u8:6", "string:ICON_URI", "string:PROJECT_URI"]' \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import {
-        bcs,
-        RESTClient,
-        MnemonicKey,
-        MsgExecute,
-        Wallet,
-    } from '@initia/initia.js';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 managed_coin initialize \
+    --args '["option<u128>:null", "string:my_coin", "string:MYCOIN", "u8:6", "string:ICON_URI", "string:PROJECT_URI"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-    async function createCoin() {
-    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-        gasPrices: '0.015uinit',
-        gasAdjustment: '1.5',
-    });
+```ts InitiaJS
+import {
+  bcs,
+  RESTClient,
+  MnemonicKey,
+  MsgExecute,
+  Wallet,
+} from '@initia/initia.js'
 
-    const key = new MnemonicKey({
-        mnemonic: 'beauty sniff protect ...',
-    });
-    const wallet = new Wallet(restClient, key);
+async function createCoin() {
+  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+    gasPrices: '0.015uinit',
+    gasAdjustment: '1.5',
+  })
 
-    const msgs = [
-        new MsgExecute(
-        key.accAddress,
-        '0x1',
-        'managed_coin',
-        'initialize',
-        [],
-        [
-            // max supply, if you want to set max supply, insert number instead of null
-            bcs.option(bcs.u128()).serialize(null).toBase64(),
-            bcs.string().serialize('my_coin').toBase64(), // name
-            bcs.string().serialize('MYCOIN').toBase64(), // symbol
-            // decimal point (raw value 1 consider to 10 ** (- decimalPoint))
-            bcs.u8().serialize(6).toBase64(),
-            bcs.string().serialize('').toBase64(), // icon uri
-            bcs.string().serialize('').toBase64(), // project uri
-        ]
-        ),
-    ];
+  const key = new MnemonicKey({
+    mnemonic: 'beauty sniff protect ...',
+  })
+  const wallet = new Wallet(restClient, key)
 
-    // sign tx
-    const signedTx = await wallet.createAndSignTx({ msgs });
-    // send(broadcast) tx
-    restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-    // {
-    //   height: 0,
-    //   txhash: '40E0D5633D37E207B2463D275F5B479FC67D545B666C37DC7B121ED551FA18FC',
-    //   raw_log: '[]'
-    // }
-    }
+  const msgs = [
+    new MsgExecute(
+      key.accAddress,
+      '0x1',
+      'managed_coin',
+      'initialize',
+      [],
+      [
+        // max supply, if you want to set max supply, insert number instead of null
+        bcs.option(bcs.u128()).serialize(null).toBase64(),
+        bcs.string().serialize('my_coin').toBase64(), // name
+        bcs.string().serialize('MYCOIN').toBase64(), // symbol
+        // decimal point (raw value 1 consider to 10 ** (- decimalPoint))
+        bcs.u8().serialize(6).toBase64(),
+        bcs.string().serialize('').toBase64(), // icon uri
+        bcs.string().serialize('').toBase64(), // project uri
+      ],
+    ),
+  ]
 
-    createCoin();
-    ```
-    </Tab>
+  // sign tx
+  const signedTx = await wallet.createAndSignTx({ msgs })
+  // send(broadcast) tx
+  restClient.tx.broadcastSync(signedTx).then((res) => console.log(res))
+  // {
+  //   height: 0,
+  //   txhash: '40E0D5633D37E207B2463D275F5B479FC67D545B666C37DC7B121ED551FA18FC',
+  //   raw_log: '[]'
+  // }
+}
 
-</Tabs>
+createCoin()
+```
+
+</CodeGroup>
 
 # Step 2: Mint Coin
 
@@ -111,144 +108,139 @@ through the `0x1::coin::metadata` view function or by using
 
 ## Obtaining Metadata
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad query move view 0x1 coin metadata \
-        --args '["address:0x...", "string:MYCOIN"]' \
-        --node [rpc-url]:[rpc-port]
+<CodeGroup>
+```bash CLI
+initiad query move view 0x1 coin metadata \
+    --args '["address:0x...", "string:MYCOIN"]' \
+    --node [rpc-url]:[rpc-port]
 
-    # data: '"0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb"'
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import { bcs, RESTClient, MnemonicKey } from '@initia/initia.js';
-    import * as crypto from 'crypto';
+# data: '"0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb"'
 
-    async function getCoinMetadata() {
-        const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-            gasPrices: '0.015uinit',
-            gasAdjustment: '1.5',
-        });
+````
 
-        const key = new MnemonicKey({
-            mnemonic: 'beauty sniff protect ...',
-        });
+```ts InitiaJS
+import { bcs, RESTClient, MnemonicKey } from '@initia/initia.js';
+import * as crypto from 'crypto';
 
-        // Method 1: use view function
-        restClient.move
-            .viewFunction(
-            '0x1',
-            'coin',
-            'metadata',
-            [],
-            [
-                bcs.address().serialize(key.accAddress).toBase64(),
-                bcs.string().serialize('MYCOIN').toBase64(),
-            ]
-            )
-            .then(console.log);
-        // 0xcf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
+async function getCoinMetadata() {
+    const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+        gasPrices: '0.015uinit',
+        gasAdjustment: '1.5',
+    });
 
-        // Method 2: use sha3-256
-        console.log(coinMetadata(key.accAddress, 'MYCOIN'));
-        // cf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
-    }
+    const key = new MnemonicKey({
+        mnemonic: 'beauty sniff protect ...',
+    });
 
-    getCoinMetadata();
+    // Method 1: use view function
+    restClient.move
+        .viewFunction(
+        '0x1',
+        'coin',
+        'metadata',
+        [],
+        [
+            bcs.address().serialize(key.accAddress).toBase64(),
+            bcs.string().serialize('MYCOIN').toBase64(),
+        ]
+        )
+        .then(console.log);
+    // 0xcf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
 
-    function coinMetadata(creator: string, symbol: string): string {
-        const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe;
-        const addrBytes = bcs.address().serialize(creator).toBytes();
-        const seed = Buffer.from(symbol, 'ascii');
-        const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME];
-        const hash = crypto.createHash('SHA3-256');
-        const digest = hash.update(Buffer.from(bytes)).digest();
-        return digest.toString('hex');
-    }
-    ```
-    </Tab>
+    // Method 2: use sha3-256
+    console.log(coinMetadata(key.accAddress, 'MYCOIN'));
+    // cf921815f2b4827930ac01b3116ed3caad08ccd443f9df6eb22cd5344a548660
+}
 
-</Tabs>
+getCoinMetadata();
+
+function coinMetadata(creator: string, symbol: string): string {
+    const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe;
+    const addrBytes = bcs.address().serialize(creator).toBytes();
+    const seed = Buffer.from(symbol, 'ascii');
+    const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME];
+    const hash = crypto.createHash('SHA3-256');
+    const digest = hash.update(Buffer.from(bytes)).digest();
+    return digest.toString('hex');
+}
+````
+
+</CodeGroup>
 
 ## Minting Coins
 
-<Tabs>
-    <Tab title="CLI">
-    ```bash
-    initiad tx move execute 0x1 managed_coin mint \
-        --args '["address:0x...", "object:0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb", "u64:100000000"]' \
-        --from [key-name] \
-        --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
-        --node [rpc-url]:[rpc-port] --chain-id [chain-id]
-    ```
-    </Tab>
-    <Tab title="InitiaJS">
-    ```ts
-    import {
-        bcs,
-        RESTClient,
-        MnemonicKey,
-        MsgExecute,
-        Wallet,
-    } from '@initia/initia.js';
-    import * as crypto from 'crypto';
+<CodeGroup>
+```bash CLI
+initiad tx move execute 0x1 managed_coin mint \
+    --args '["address:0x...", "object:0x2d81ce0b6708fccc77a537d3d1abac8c9f1f674f4f76390e3e78a89a52d4aacb", "u64:100000000"]' \
+    --from [key-name] \
+    --gas auto --gas-adjustment 1.5 --gas-prices 0.015uinit \
+    --node [rpc-url]:[rpc-port] --chain-id [chain-id]
+```
 
-    async function mintCoin() {
-        const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
-            gasPrices: '0.015uinit',
-            gasAdjustment: '1.5',
-        });
+```ts InitiaJS
+import {
+  bcs,
+  RESTClient,
+  MnemonicKey,
+  MsgExecute,
+  Wallet,
+} from '@initia/initia.js'
+import * as crypto from 'crypto'
 
-        const key = new MnemonicKey({
-            mnemonic: 'beauty sniff protect ...',
-        });
-        const wallet = new Wallet(restClient, key);
+async function mintCoin() {
+  const restClient = new RESTClient('https://rest.testnet.initia.xyz', {
+    gasPrices: '0.015uinit',
+    gasAdjustment: '1.5',
+  })
 
-        const msgs = [
-            new MsgExecute(
-            key.accAddress,
-            '0x1',
-            'managed_coin',
-            'mint',
-            [],
-            [
-                bcs.address().serialize(key.accAddress).toBase64(),
-                bcs
-                .object()
-                .serialize(coinMetadata(key.accAddress, 'MYCOIN'))
-                .toBase64(),
-                bcs.u64().serialize(100000000).toBase64(),
-            ]
-            ),
-        ];
+  const key = new MnemonicKey({
+    mnemonic: 'beauty sniff protect ...',
+  })
+  const wallet = new Wallet(restClient, key)
 
-        // sign tx
-        const signedTx = await wallet.createAndSignTx({ msgs });
-        // send(broadcast) tx
-        restClient.tx.broadcastSync(signedTx).then(res => console.log(res));
-        // {
-        //   height: 0,
-        //   txhash: '593827F58F3E811686EC6FFDAD2E27E91DA707965F0FF33093DC071D47A46786',
-        //   raw_log: '[]'
-        // }
-    }
+  const msgs = [
+    new MsgExecute(
+      key.accAddress,
+      '0x1',
+      'managed_coin',
+      'mint',
+      [],
+      [
+        bcs.address().serialize(key.accAddress).toBase64(),
+        bcs
+          .object()
+          .serialize(coinMetadata(key.accAddress, 'MYCOIN'))
+          .toBase64(),
+        bcs.u64().serialize(100000000).toBase64(),
+      ],
+    ),
+  ]
 
-    mintCoin();
+  // sign tx
+  const signedTx = await wallet.createAndSignTx({ msgs })
+  // send(broadcast) tx
+  restClient.tx.broadcastSync(signedTx).then((res) => console.log(res))
+  // {
+  //   height: 0,
+  //   txhash: '593827F58F3E811686EC6FFDAD2E27E91DA707965F0FF33093DC071D47A46786',
+  //   raw_log: '[]'
+  // }
+}
 
-    function coinMetadata(creator: string, symbol: string): string {
-        const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe;
-        const addrBytes = bcs.address().serialize(creator).toBytes();
-        const seed = Buffer.from(symbol, 'ascii');
-        const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME];
-        const hash = crypto.createHash('SHA3-256');
-        const digest = hash.update(Buffer.from(bytes)).digest();
-        return digest.toString('hex');
-    }
-    ```
-    </Tab>
+mintCoin()
 
-</Tabs>
+function coinMetadata(creator: string, symbol: string): string {
+  const OBJECT_FROM_SEED_ADDRESS_SCHEME = 0xfe
+  const addrBytes = bcs.address().serialize(creator).toBytes()
+  const seed = Buffer.from(symbol, 'ascii')
+  const bytes = [...addrBytes, ...seed, OBJECT_FROM_SEED_ADDRESS_SCHEME]
+  const hash = crypto.createHash('SHA3-256')
+  const digest = hash.update(Buffer.from(bytes)).digest()
+  return digest.toString('hex')
+}
+```
+
+</CodeGroup>
 
 After minting, you can check the balances to verify the minting process.

--- a/developers/developer-guides/vm-specific-tutorials/movevm/setting-up.mdx
+++ b/developers/developer-guides/vm-specific-tutorials/movevm/setting-up.mdx
@@ -203,13 +203,13 @@ For testnet development, use the official Initia faucet to get free tokens:
 After funding, verify your account has received tokens:
 
 <CodeGroup>
-```bash Initia L1
-initiad query bank balances [your-address]
-```
+  <CodeBlock filename="Initia L1" language="bash">
+    initiad query bank balances [your-address]
+  </CodeBlock>
 
-```bash Move Rollups
-minitiad query bank balances [your-address]
-```
+  <CodeBlock filename="Move Rollups" language="bash">
+    minitiad query bank balances [your-address]
+  </CodeBlock>
 </CodeGroup>
 </Step>
 </Steps>

--- a/developers/developer-guides/vm-specific-tutorials/movevm/setting-up.mdx
+++ b/developers/developer-guides/vm-specific-tutorials/movevm/setting-up.mdx
@@ -202,18 +202,15 @@ For testnet development, use the official Initia faucet to get free tokens:
 
 After funding, verify your account has received tokens:
 
-<Tabs>
-<Tab title="Initia L1">
-```bash
+<CodeGroup>
+```bash Initia L1
 initiad query bank balances [your-address]
 ```
-</Tab>
-<Tab title="Move Rollups">
-```bash
+
+```bash Move Rollups
 minitiad query bank balances [your-address]
 ```
-</Tab>
-</Tabs>
+</CodeGroup>
 </Step>
 </Steps>
 

--- a/interwovenkit/integrations/evm.mdx
+++ b/interwovenkit/integrations/evm.mdx
@@ -109,17 +109,17 @@ To follow the implementation example, install `viem` for Ethereum utilities:
     npm install viem
   </CodeBlock>
 
-  <CodeBlock filename="yarn" language="sh">
-    yarn add viem
-  </CodeBlock>
+<CodeBlock filename="yarn" language="sh">
+  yarn add viem
+</CodeBlock>
 
-  <CodeBlock filename="pnpm" language="sh">
-    pnpm add viem
-  </CodeBlock>
+<CodeBlock filename="pnpm" language="sh">
+  pnpm add viem
+</CodeBlock>
 
-  <CodeBlock filename="bun" language="sh">
-    bun add viem
-  </CodeBlock>
+<CodeBlock filename="bun" language="sh">
+  bun add viem
+</CodeBlock>
 
 </CodeGroup>
 

--- a/interwovenkit/integrations/evm.mdx
+++ b/interwovenkit/integrations/evm.mdx
@@ -105,21 +105,21 @@ export default function Providers({ children }: PropsWithChildren) {
 To follow the implementation example, install `viem` for Ethereum utilities:
 
 <CodeGroup>
-```sh npm
-npm install viem
-```
+  <CodeBlock filename="npm" language="sh">
+    npm install viem
+  </CodeBlock>
 
-```sh yarn
-yarn add viem
-```
+  <CodeBlock filename="yarn" language="sh">
+    yarn add viem
+  </CodeBlock>
 
-```sh pnpm
-pnpm add viem
-```
+  <CodeBlock filename="pnpm" language="sh">
+    pnpm add viem
+  </CodeBlock>
 
-```sh bun
-bun add viem
-```
+  <CodeBlock filename="bun" language="sh">
+    bun add viem
+  </CodeBlock>
 
 </CodeGroup>
 

--- a/interwovenkit/integrations/evm.mdx
+++ b/interwovenkit/integrations/evm.mdx
@@ -104,12 +104,24 @@ export default function Providers({ children }: PropsWithChildren) {
 
 To follow the implementation example, install `viem` for Ethereum utilities:
 
-<Tabs>
-  <Tab title="npm">```sh npm npm install viem ```</Tab>
-  <Tab title="yarn">```sh yarn yarn add viem ```</Tab>
-  <Tab title="pnpm">```sh pnpm pnpm add viem ```</Tab>
-  <Tab title="bun">```sh bun bun add viem ```</Tab>
-</Tabs>
+<CodeGroup>
+```sh npm
+npm install viem
+```
+
+```sh yarn
+yarn add viem
+```
+
+```sh pnpm
+pnpm add viem
+```
+
+```sh bun
+bun add viem
+```
+
+</CodeGroup>
 
 </Step>
 <Step title="Implementation Example">


### PR DESCRIPTION
- Convert code-only tab sets to `CodeGroup`.
- Preserve non-code tab layouts.
- Use explicit `CodeBlock` children instead of raw fenced blocks inside `CodeGroup`.
- Improve consistency and reduce formatting churn from `prettier`.